### PR TITLE
Make `Http` API methods generic over their return type

### DIFF
--- a/src/builder/bot_auth_parameters.rs
+++ b/src/builder/bot_auth_parameters.rs
@@ -86,7 +86,8 @@ impl<'a> CreateBotAuthParameters<'a> {
     /// [`HttpError::UnsuccessfulRequest`]: crate::http::HttpError::UnsuccessfulRequest
     #[cfg(feature = "http")]
     pub async fn auto_client_id(mut self, http: &Http) -> Result<Self> {
-        self.client_id = http.get_current_application_info().await.map(|v| Some(v.id))?;
+        let info: CurrentApplicationInfo = http.get_current_application_info().await?;
+        self.client_id = Some(info.id);
         Ok(self)
     }
 

--- a/src/builder/edit_channel.rs
+++ b/src/builder/edit_channel.rs
@@ -339,9 +339,8 @@ impl<'a> EditChannel<'a> {
             .await?;
         }
 
-        http.edit_channel(channel_id.widen(), &self, self.audit_log_reason)
-            .await?
-            .guild()
-            .ok_or(Error::Model(ModelError::InvalidChannelType))
+        let channel: Channel =
+            http.edit_channel(channel_id.widen(), &self, self.audit_log_reason).await?;
+        channel.guild().ok_or(Error::Model(ModelError::InvalidChannelType))
     }
 }

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -169,7 +169,7 @@ impl<'a> EditRole<'a> {
         guild_id: GuildId,
         role_id: Option<RoleId>,
     ) -> Result<Role> {
-        let role = match role_id {
+        let role: Role = match role_id {
             Some(role_id) => {
                 http.edit_role(guild_id, role_id, &self, self.audit_log_reason).await?
             },

--- a/src/builder/edit_thread.rs
+++ b/src/builder/edit_thread.rs
@@ -109,9 +109,8 @@ impl<'a> EditThread<'a> {
     /// Returns [`ModelError::InvalidChannelType`] if the `ThreadId` is not identifying a thread.
     #[cfg(feature = "http")]
     pub async fn execute(self, http: &Http, thread_id: ThreadId) -> Result<GuildThread> {
-        http.edit_channel(thread_id.widen(), &self, self.audit_log_reason)
-            .await?
-            .thread()
-            .ok_or(Error::Model(ModelError::InvalidChannelType))
+        let channel: Channel =
+            http.edit_channel(thread_id.widen(), &self, self.audit_log_reason).await?;
+        channel.thread().ok_or(Error::Model(ModelError::InvalidChannelType))
     }
 }

--- a/src/gateway/client/mod.rs
+++ b/src/gateway/client/mod.rs
@@ -60,9 +60,11 @@ use crate::framework::Framework;
 use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::internal::tokio::spawn_named;
-use crate::model::gateway::GatewayIntents;
+use crate::model::gateway::{BotGateway, GatewayIntents};
 #[cfg(feature = "voice")]
 use crate::model::id::UserId;
+#[cfg(feature = "voice")]
+use crate::model::user::CurrentUser;
 use crate::model::user::OnlineStatus;
 
 /// A builder implementing [`IntoFuture`] building a [`Client`] to interact with Discord.
@@ -305,17 +307,18 @@ impl IntoFuture for ClientBuilder {
         let cache = Arc::new(Cache::new_with_settings(self.cache_settings));
 
         Box::pin(async move {
-            let (ws_url, shard_total, max_concurrency) = match http.get_bot_gateway().await {
-                Ok(response) => (
-                    Arc::from(response.url),
-                    response.shards,
-                    response.session_start_limit.max_concurrency,
-                ),
-                Err(err) => {
-                    tracing::warn!("HTTP request to get gateway URL failed: {err}");
-                    (Arc::from("wss://gateway.discord.gg"), NonZeroU16::MIN, NonZeroU16::MIN)
-                },
-            };
+            let (ws_url, shard_total, max_concurrency) =
+                match http.get_bot_gateway::<BotGateway>().await {
+                    Ok(response) => (
+                        Arc::from(response.url),
+                        response.shards,
+                        response.session_start_limit.max_concurrency,
+                    ),
+                    Err(err) => {
+                        tracing::warn!("HTTP request to get gateway URL failed: {err}");
+                        (Arc::from("wss://gateway.discord.gg"), NonZeroU16::MIN, NonZeroU16::MIN)
+                    },
+                };
 
             #[cfg(feature = "framework")]
             let framework_cell = Arc::new(OnceLock::new());
@@ -507,7 +510,7 @@ impl Client {
     #[cfg_attr(feature = "tracing_instrument", instrument(skip(self)))]
     pub async fn start_autosharded(&mut self) -> Result<()> {
         let (end, total) = {
-            let res = self.http.get_bot_gateway().await?;
+            let res: BotGateway = self.http.get_bot_gateway().await?;
             (res.shards.get() - 1, res.shards)
         };
 
@@ -681,7 +684,7 @@ impl Client {
 
             let user_id = match cache_user_id {
                 Some(u) => u,
-                None => self.http.get_current_user().await?.id,
+                None => self.http.get_current_user::<CurrentUser>().await?.id,
             };
 
             voice_manager.initialise(total_shards, user_id).await;

--- a/src/gateway/sharding/mod.rs
+++ b/src/gateway/sharding/mod.rs
@@ -118,7 +118,7 @@ impl Shard {
     /// use std::sync::Arc;
     ///
     /// use serenity::gateway::{Shard, TransportCompression};
-    /// use serenity::model::gateway::{GatewayIntents, ShardInfo};
+    /// use serenity::model::gateway::{Gateway, GatewayIntents, ShardInfo};
     /// use serenity::model::id::ShardId;
     /// use serenity::secrets::Token;
     /// use tokio::sync::Mutex;
@@ -134,7 +134,7 @@ impl Shard {
     /// };
     ///
     /// // retrieve the gateway response, which contains the URL to connect to
-    /// let gateway = Arc::from(http.get_gateway().await?.url);
+    /// let gateway = Arc::from(http.get_gateway::<Gateway>().await?.url);
     /// let shard = Shard::new(
     ///     gateway,
     ///     token,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -13,7 +13,7 @@ use reqwest::Url;
 use reqwest::header::{HeaderMap as Headers, HeaderValue};
 use reqwest::{Client, ClientBuilder, Response as ReqwestResponse, StatusCode};
 use serde::de::DeserializeOwned;
-use serde::ser::SerializeSeq as _;
+use serde::ser::{Serialize, SerializeSeq as _, Serializer};
 use serde_json::{from_value, to_string, to_vec};
 use to_arraystring::ToArrayString as _;
 #[cfg(feature = "tracing_instrument")]
@@ -45,12 +45,12 @@ impl<I> SerializeIter<I> {
     }
 }
 
-impl<Iter, Item> serde::Serialize for SerializeIter<Iter>
+impl<Iter, Item> Serialize for SerializeIter<Iter>
 where
     Iter: Iterator<Item = Item>,
-    Item: serde::Serialize,
+    Item: Serialize,
 {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let Some(iter) = self.0.take() else {
             return serializer.serialize_seq(Some(0))?.end();
         };
@@ -277,12 +277,12 @@ impl Http {
     /// Adds a [`User`] to a [`Guild`] with a valid OAuth2 access token.
     ///
     /// Returns the created [`Member`] object, or nothing if the user is already a guild member.
-    pub async fn add_guild_member(
+    pub async fn add_guild_member<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         user_id: UserId,
-        map: &impl serde::Serialize,
-    ) -> Result<Option<Member>> {
+        map: &impl Serialize,
+    ) -> Result<Option<T>> {
         let response = self
             .request(Request {
                 body: Some(to_vec(map)?),
@@ -353,12 +353,12 @@ impl Http {
     ///
     /// See the [Discord docs](https://docs.discord.com/developers/resources/guild#bulk-guild-ban)
     /// for more information.
-    pub async fn bulk_ban_users(
+    pub async fn bulk_ban_users<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         reason: Option<&str>,
-    ) -> Result<BulkBanResponse> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -388,12 +388,12 @@ impl Http {
     }
 
     /// Creates a [`GuildChannel`] in the [`Guild`] given its Id.
-    pub async fn create_channel(
+    pub async fn create_channel<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<GuildChannel> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -408,11 +408,11 @@ impl Http {
     }
 
     /// Creates a stage instance.
-    pub async fn create_stage_instance(
+    pub async fn create_stage_instance<T: DeserializeOwned>(
         &self,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<StageInstance> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -425,13 +425,13 @@ impl Http {
     }
 
     /// Creates a thread channel in the [`GuildChannel`] given its Id, with a base message Id.
-    pub async fn create_thread_from_message(
+    pub async fn create_thread_from_message<T: DeserializeOwned>(
         &self,
         channel_id: ChannelId,
         message_id: MessageId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<GuildThread> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -447,12 +447,12 @@ impl Http {
     }
 
     /// Creates a thread channel not attached to a message in the [`GuildChannel`] given its Id.
-    pub async fn create_thread(
+    pub async fn create_thread<T: DeserializeOwned>(
         &self,
         channel_id: ChannelId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<GuildThread> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -467,13 +467,13 @@ impl Http {
     }
 
     /// Creates a forum post channel in the [`GuildChannel`] given its Id.
-    pub async fn create_forum_post(
+    pub async fn create_forum_post<T: DeserializeOwned>(
         &self,
         channel_id: ChannelId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         files: Vec<AttachmentData<'_>>,
         audit_log_reason: Option<&str>,
-    ) -> Result<GuildThread> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: Some(Multipart {
@@ -492,12 +492,12 @@ impl Http {
     }
 
     /// Creates an emoji in the given [`Guild`] with the given data.
-    pub async fn create_emoji(
+    pub async fn create_emoji<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<Emoji> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -516,7 +516,10 @@ impl Http {
     /// See [`Context::create_application_emoji`] for required fields.
     ///
     /// [`Context::create_application_emoji`]: crate::gateway::client::Context::create_application_emoji
-    pub async fn create_application_emoji(&self, map: &impl serde::Serialize) -> Result<Emoji> {
+    pub async fn create_application_emoji<T: DeserializeOwned>(
+        &self,
+        map: &impl Serialize,
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -533,12 +536,12 @@ impl Http {
     /// Create a follow-up message for an Interaction.
     ///
     /// Functions the same as [`Self::execute_webhook`]
-    pub async fn create_followup_message(
+    pub async fn create_followup_message<T: DeserializeOwned>(
         &self,
         interaction_token: &str,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         files: Vec<AttachmentData<'_>>,
-    ) -> Result<Message> {
+    ) -> Result<T> {
         let mut request = Request {
             body: None,
             multipart: None,
@@ -565,7 +568,10 @@ impl Http {
     }
 
     /// Creates a new global command.
-    pub async fn create_global_command(&self, map: &impl serde::Serialize) -> Result<Command> {
+    pub async fn create_global_command<T: DeserializeOwned>(
+        &self,
+        map: &impl Serialize,
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -580,10 +586,10 @@ impl Http {
     }
 
     /// Creates new global application commands.
-    pub async fn create_global_commands(
+    pub async fn create_global_commands<T: DeserializeOwned>(
         &self,
-        map: &impl serde::Serialize,
-    ) -> Result<Vec<Command>> {
+        map: &impl Serialize,
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -598,11 +604,11 @@ impl Http {
     }
 
     /// Creates new guild application commands.
-    pub async fn create_guild_commands(
+    pub async fn create_guild_commands<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
-    ) -> Result<Vec<Command>> {
+        map: &impl Serialize,
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -624,7 +630,7 @@ impl Http {
     ///
     /// [`Shard`]: crate::gateway::Shard
     #[deprecated = "This endpoint has been deprecated by Discord and will stop functioning after July 15, 2025. For more information, see: https://docs.discord.com/developers/change-log#deprecating-guild-creation-by-apps"]
-    pub async fn create_guild(&self, map: &impl serde::Serialize) -> Result<PartialGuild> {
+    pub async fn create_guild<T: DeserializeOwned>(&self, map: &impl Serialize) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -639,11 +645,11 @@ impl Http {
     /// Creates a new guild command.
     ///
     /// New guild commands will be available in the guild immediately.
-    pub async fn create_guild_command(
+    pub async fn create_guild_command<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
-    ) -> Result<Command> {
+        map: &impl Serialize,
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -663,7 +669,7 @@ impl Http {
         &self,
         guild_id: GuildId,
         integration_id: IntegrationId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
         self.wind(Request {
@@ -685,7 +691,7 @@ impl Http {
         &self,
         interaction_id: InteractionId,
         interaction_token: &str,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         files: Vec<AttachmentData<'_>>,
     ) -> Result<()> {
         let mut request = Request {
@@ -714,12 +720,12 @@ impl Http {
     }
 
     /// Creates an [`Invite`] for the given [channel][`GuildChannel`].
-    pub async fn create_invite(
+    pub async fn create_invite<T: DeserializeOwned>(
         &self,
         channel_id: ChannelId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<Invite> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -738,7 +744,7 @@ impl Http {
         &self,
         channel_id: ChannelId,
         target_id: TargetId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
         self.wind(Request {
@@ -756,10 +762,10 @@ impl Http {
     }
 
     /// Creates a private channel with a user.
-    pub async fn create_private_channel(
+    pub async fn create_private_channel<T: DeserializeOwned>(
         &self,
-        map: &impl serde::Serialize,
-    ) -> Result<PrivateChannel> {
+        map: &impl Serialize,
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -794,12 +800,12 @@ impl Http {
     }
 
     /// Creates a role.
-    pub async fn create_role(
+    pub async fn create_role<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<Role> {
+    ) -> Result<T> {
         let mut value: Value = self
             .fire(Request {
                 body: Some(to_vec(map)?),
@@ -821,12 +827,12 @@ impl Http {
     }
 
     /// Creates a Guild Scheduled Event.
-    pub async fn create_scheduled_event(
+    pub async fn create_scheduled_event<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<ScheduledEvent> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -841,13 +847,13 @@ impl Http {
     }
 
     /// Creates a sticker.
-    pub async fn create_sticker(
+    pub async fn create_sticker<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         fields: Vec<(Cow<'static, str>, Cow<'static, str>)>,
         file: AttachmentData<'_>,
         audit_log_reason: Option<&str>,
-    ) -> Result<Sticker> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: Some(Multipart {
@@ -868,10 +874,10 @@ impl Http {
     /// Creates a test entitlement to a given SKU for a given guild or user. Discord will act as
     /// though that user/guild has entitlement in perpetuity to the SKU. As a result, the returned
     /// entitlement will have `starts_at` and `ends_at` both be `None`.
-    pub async fn create_test_entitlement(
+    pub async fn create_test_entitlement<T: DeserializeOwned>(
         &self,
-        map: &impl serde::Serialize,
-    ) -> Result<Entitlement> {
+        map: &impl Serialize,
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(&map)?),
             multipart: None,
@@ -886,12 +892,12 @@ impl Http {
     }
 
     /// Creates a webhook for the given [`GuildChannel`]'s Id, passing in the given data.
-    pub async fn create_webhook(
+    pub async fn create_webhook<T: DeserializeOwned>(
         &self,
         channel_id: ChannelId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<Webhook> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -906,11 +912,11 @@ impl Http {
     }
 
     /// Deletes a private channel or a channel in a guild.
-    pub async fn delete_channel(
+    pub async fn delete_channel<T: DeserializeOwned>(
         &self,
         channel_id: GenericChannelId,
         audit_log_reason: Option<&str>,
-    ) -> Result<Channel> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -1075,11 +1081,11 @@ impl Http {
     }
 
     /// Deletes an invite by code.
-    pub async fn delete_invite(
+    pub async fn delete_invite<T: DeserializeOwned>(
         &self,
         code: &str,
         audit_log_reason: Option<&str>,
-    ) -> Result<Invite> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -1118,7 +1124,7 @@ impl Http {
     pub async fn delete_messages(
         &self,
         channel_id: GenericChannelId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
         self.wind(Request {
@@ -1384,12 +1390,12 @@ impl Http {
     }
 
     /// Changes channel information.
-    pub async fn edit_channel(
+    pub async fn edit_channel<T: DeserializeOwned>(
         &self,
         channel_id: GenericChannelId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<Channel> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -1404,12 +1410,12 @@ impl Http {
     }
 
     /// Edits a stage instance.
-    pub async fn edit_stage_instance(
+    pub async fn edit_stage_instance<T: DeserializeOwned>(
         &self,
         channel_id: ChannelId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<StageInstance> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -1424,13 +1430,13 @@ impl Http {
     }
 
     /// Changes guild emoji information.
-    pub async fn edit_emoji(
+    pub async fn edit_emoji<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         emoji_id: EmojiId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<Emoji> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -1450,11 +1456,11 @@ impl Http {
     /// See [`Context::edit_application_emoji`] for required fields.
     ///
     /// [`Context::edit_application_emoji`]: crate::gateway::client::Context::edit_application_emoji
-    pub async fn edit_application_emoji(
+    pub async fn edit_application_emoji<T: DeserializeOwned>(
         &self,
         emoji_id: EmojiId,
-        map: &impl serde::Serialize,
-    ) -> Result<Emoji> {
+        map: &impl Serialize,
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -1470,13 +1476,13 @@ impl Http {
     }
 
     /// Edits a follow-up message for an interaction.
-    pub async fn edit_followup_message(
+    pub async fn edit_followup_message<T: DeserializeOwned>(
         &self,
         interaction_token: &str,
         message_id: MessageId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         new_attachments: Vec<AttachmentData<'_>>,
-    ) -> Result<Message> {
+    ) -> Result<T> {
         let mut request = Request {
             body: None,
             multipart: None,
@@ -1504,11 +1510,11 @@ impl Http {
     }
 
     /// Get a follow-up message for an interaction.
-    pub async fn get_followup_message(
+    pub async fn get_followup_message<T: DeserializeOwned>(
         &self,
         interaction_token: &str,
         message_id: MessageId,
-    ) -> Result<Message> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -1525,11 +1531,11 @@ impl Http {
     }
 
     /// Edits a global command.
-    pub async fn edit_global_command(
+    pub async fn edit_global_command<T: DeserializeOwned>(
         &self,
         command_id: CommandId,
-        map: &impl serde::Serialize,
-    ) -> Result<Command> {
+        map: &impl Serialize,
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -1545,12 +1551,12 @@ impl Http {
     }
 
     /// Changes guild information.
-    pub async fn edit_guild(
+    pub async fn edit_guild<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<PartialGuild> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -1565,12 +1571,12 @@ impl Http {
     }
 
     /// Edits a guild command.
-    pub async fn edit_guild_command(
+    pub async fn edit_guild_command<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         command_id: CommandId,
-        map: &impl serde::Serialize,
-    ) -> Result<Command> {
+        map: &impl Serialize,
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -1587,12 +1593,12 @@ impl Http {
     }
 
     /// Edits a guild command permissions.
-    pub async fn edit_guild_command_permissions(
+    pub async fn edit_guild_command_permissions<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         command_id: CommandId,
-        map: &impl serde::Serialize,
-    ) -> Result<CommandPermissions> {
+        map: &impl Serialize,
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -1612,7 +1618,7 @@ impl Http {
     pub async fn edit_guild_channel_positions(
         &self,
         guild_id: GuildId,
-        value: impl Iterator<Item: serde::Serialize>,
+        value: impl Iterator<Item: Serialize>,
     ) -> Result<()> {
         let body = to_vec(&SerializeIter::new(value))?;
 
@@ -1630,38 +1636,38 @@ impl Http {
     }
 
     /// Edits the MFA level of a guild. Requires guild ownership.
-    pub async fn edit_guild_mfa_level(
+    pub async fn edit_guild_mfa_level<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<MfaLevel> {
-        #[derive(Deserialize)]
-        struct GuildMfaLevel {
-            level: MfaLevel,
-        }
+    ) -> Result<T> {
+        let resp = self
+            .fire::<Value>(Request {
+                body: Some(to_vec(map)?),
+                multipart: None,
+                headers: audit_log_reason.map(reason_into_header),
+                method: LightMethod::Post,
+                route: Route::GuildMfa {
+                    guild_id,
+                },
+                params: None,
+            })
+            .await?
+            .get_mut("level")
+            .map(Value::take)
+            .unwrap_or_default();
 
-        self.fire(Request {
-            body: Some(to_vec(map)?),
-            multipart: None,
-            headers: audit_log_reason.map(reason_into_header),
-            method: LightMethod::Post,
-            route: Route::GuildMfa {
-                guild_id,
-            },
-            params: None,
-        })
-        .await
-        .map(|mfa: GuildMfaLevel| mfa.level)
+        from_value(resp).map_err(From::from)
     }
 
     /// Edits a [`Guild`]'s widget.
-    pub async fn edit_guild_widget(
+    pub async fn edit_guild_widget<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<GuildWidget> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -1676,12 +1682,12 @@ impl Http {
     }
 
     /// Edits a guild welcome screen.
-    pub async fn edit_guild_welcome_screen(
+    pub async fn edit_guild_welcome_screen<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<GuildWelcomeScreen> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -1696,13 +1702,13 @@ impl Http {
     }
 
     /// Does specific actions to a member.
-    pub async fn edit_member(
+    pub async fn edit_member<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         user_id: UserId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<Member> {
+    ) -> Result<T> {
         let mut value: Value = self
             .fire(Request {
                 body: Some(to_vec(map)?),
@@ -1721,19 +1727,19 @@ impl Http {
             map.insert("guild_id".to_string(), guild_id.get().into());
         }
 
-        from_value::<Member>(value).map_err(From::from)
+        from_value(value).map_err(From::from)
     }
 
     /// Edits a message by Id.
     ///
     /// **Note**: Only the author of a message can modify it.
-    pub async fn edit_message(
+    pub async fn edit_message<T: DeserializeOwned>(
         &self,
         channel_id: GenericChannelId,
         message_id: MessageId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         new_attachments: Vec<AttachmentData<'_>>,
-    ) -> Result<Message> {
+    ) -> Result<T> {
         let mut request = Request {
             body: None,
             multipart: None,
@@ -1762,11 +1768,11 @@ impl Http {
     /// Crossposts a message by Id.
     ///
     /// **Note**: Only available on news channels.
-    pub async fn crosspost_message(
+    pub async fn crosspost_message<T: DeserializeOwned>(
         &self,
         channel_id: ChannelId,
         message_id: MessageId,
-    ) -> Result<Message> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -1782,12 +1788,12 @@ impl Http {
     }
 
     /// Edits the current member for the provided [`Guild`] via its Id.
-    pub async fn edit_current_member(
+    pub async fn edit_current_member<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<Member> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(&map)?),
             multipart: None,
@@ -1802,11 +1808,11 @@ impl Http {
     }
 
     /// Follow a News Channel to send messages to a target channel.
-    pub async fn follow_news_channel(
+    pub async fn follow_news_channel<T: DeserializeOwned>(
         &self,
         news_channel_id: ChannelId,
-        map: &impl serde::Serialize,
-    ) -> Result<FollowedChannel> {
+        map: &impl Serialize,
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(&map)?),
             multipart: None,
@@ -1821,10 +1827,10 @@ impl Http {
     }
 
     /// Gets the initial interaction response.
-    pub async fn get_original_interaction_response(
+    pub async fn get_original_interaction_response<T: DeserializeOwned>(
         &self,
         interaction_token: &str,
-    ) -> Result<Message> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -1840,12 +1846,12 @@ impl Http {
     }
 
     /// Edits the initial interaction response.
-    pub async fn edit_original_interaction_response(
+    pub async fn edit_original_interaction_response<T: DeserializeOwned>(
         &self,
         interaction_token: &str,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         new_attachments: Vec<AttachmentData<'_>>,
-    ) -> Result<Message> {
+    ) -> Result<T> {
         let mut request = Request {
             body: None,
             multipart: None,
@@ -1872,7 +1878,7 @@ impl Http {
     }
 
     /// Edits the current user's profile settings.
-    pub async fn edit_profile(&self, map: &impl serde::Serialize) -> Result<CurrentUser> {
+    pub async fn edit_profile<T: DeserializeOwned>(&self, map: &impl Serialize) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -1885,13 +1891,13 @@ impl Http {
     }
 
     /// Changes a role in a guild.
-    pub async fn edit_role(
+    pub async fn edit_role<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         role_id: RoleId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<Role> {
+    ) -> Result<T> {
         let mut value: Value = self
             .fire(Request {
                 body: Some(to_vec(map)?),
@@ -1914,12 +1920,12 @@ impl Http {
     }
 
     /// Changes the positions of roles in a guild.
-    pub async fn edit_role_positions(
+    pub async fn edit_role_positions<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        positions: impl Iterator<Item: serde::Serialize>,
+        positions: impl Iterator<Item: Serialize>,
         audit_log_reason: Option<&str>,
-    ) -> Result<Vec<Role>> {
+    ) -> Result<Vec<T>> {
         let body = to_vec(&SerializeIter::new(positions))?;
 
         let mut value: Value = self
@@ -1951,13 +1957,13 @@ impl Http {
     /// **Note**: Requires the [Manage Events] permission.
     ///
     /// [Manage Events]: Permissions::MANAGE_EVENTS
-    pub async fn edit_scheduled_event(
+    pub async fn edit_scheduled_event<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         event_id: ScheduledEventId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<ScheduledEvent> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -1975,13 +1981,13 @@ impl Http {
     /// Changes a sticker in a guild.
     ///
     /// See [`GuildId::edit_sticker`] for permissions requirements.
-    pub async fn edit_sticker(
+    pub async fn edit_sticker<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         sticker_id: StickerId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<Sticker> {
+    ) -> Result<T> {
         let mut value: Value = self
             .fire(Request {
                 body: Some(to_vec(map)?),
@@ -2008,7 +2014,7 @@ impl Http {
         &self,
         guild_id: GuildId,
         user_id: UserId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
     ) -> Result<()> {
         self.wind(Request {
             body: Some(to_vec(map)?),
@@ -2025,11 +2031,7 @@ impl Http {
     }
 
     /// Changes the current user's voice state in a stage channel.
-    pub async fn edit_voice_state_me(
-        &self,
-        guild_id: GuildId,
-        map: &impl serde::Serialize,
-    ) -> Result<()> {
+    pub async fn edit_voice_state_me(&self, guild_id: GuildId, map: &impl Serialize) -> Result<()> {
         self.wind(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -2047,7 +2049,7 @@ impl Http {
     pub async fn edit_voice_status(
         &self,
         channel_id: ChannelId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
         self.wind(Request {
@@ -2064,12 +2066,12 @@ impl Http {
     }
 
     /// Edits a the webhook with the given data.
-    pub async fn edit_webhook(
+    pub async fn edit_webhook<T: DeserializeOwned>(
         &self,
         webhook_id: WebhookId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<Webhook> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -2084,13 +2086,13 @@ impl Http {
     }
 
     /// Edits the webhook with the given data.
-    pub async fn edit_webhook_with_token(
+    pub async fn edit_webhook_with_token<T: DeserializeOwned>(
         &self,
         webhook_id: WebhookId,
         token: &str,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<Webhook> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -2106,15 +2108,15 @@ impl Http {
     }
 
     /// Executes a webhook, posting a [`Message`] in the webhook's associated [`Channel`].
-    pub async fn execute_webhook(
+    pub async fn execute_webhook<T: DeserializeOwned>(
         &self,
         webhook_id: WebhookId,
         thread_id: Option<ThreadId>,
         token: &str,
         wait: bool,
         files: Vec<AttachmentData<'_>>,
-        map: &impl serde::Serialize,
-    ) -> Result<Option<Message>> {
+        map: &impl Serialize,
+    ) -> Result<Option<T>> {
         self.execute_webhook_(webhook_id, thread_id, token, wait, files, map, false).await
     }
 
@@ -2124,29 +2126,29 @@ impl Http {
     /// Refer to the [Discord docs] for more information on how this works.
     ///
     /// [Discord docs]: https://docs.discord.com/developers/resources/webhook#execute-webhook-query-string-params
-    pub async fn execute_webhook_with_components(
+    pub async fn execute_webhook_with_components<T: DeserializeOwned>(
         &self,
         webhook_id: WebhookId,
         thread_id: Option<ThreadId>,
         token: &str,
         wait: bool,
         files: Vec<AttachmentData<'_>>,
-        map: &impl serde::Serialize,
-    ) -> Result<Option<Message>> {
+        map: &impl Serialize,
+    ) -> Result<Option<T>> {
         self.execute_webhook_(webhook_id, thread_id, token, wait, files, map, true).await
     }
 
     #[expect(clippy::too_many_arguments)]
-    async fn execute_webhook_(
+    async fn execute_webhook_<T: DeserializeOwned>(
         &self,
         webhook_id: WebhookId,
         thread_id: Option<ThreadId>,
         token: &str,
         wait: bool,
         files: Vec<AttachmentData<'_>>,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         with_components: bool,
-    ) -> Result<Option<Message>> {
+    ) -> Result<Option<T>> {
         let (thread_id_str, with_components_str);
         let wait_str = wait.to_arraystring();
         let mut params = ArrayVec::<_, 3>::new();
@@ -2190,13 +2192,13 @@ impl Http {
     }
 
     // Gets a webhook's message by Id
-    pub async fn get_webhook_message(
+    pub async fn get_webhook_message<T: DeserializeOwned>(
         &self,
         webhook_id: WebhookId,
         thread_id: Option<ThreadId>,
         token: &str,
         message_id: MessageId,
-    ) -> Result<Message> {
+    ) -> Result<T> {
         let thread_id_str;
         let mut params = None;
 
@@ -2221,15 +2223,15 @@ impl Http {
     }
 
     /// Edits a webhook's message by Id.
-    pub async fn edit_webhook_message(
+    pub async fn edit_webhook_message<T: DeserializeOwned>(
         &self,
         webhook_id: WebhookId,
         thread_id: Option<ThreadId>,
         token: &str,
         message_id: MessageId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         new_attachments: Vec<AttachmentData<'_>>,
-    ) -> Result<Message> {
+    ) -> Result<T> {
         let thread_id_str;
         let mut params = None;
 
@@ -2298,15 +2300,9 @@ impl Http {
     /// Gets the active maintenances from Discord's Status API.
     ///
     /// Does not require authentication.
-    pub async fn get_active_maintenances(&self) -> Result<Vec<Maintenance>> {
-        #[derive(Deserialize)]
-        struct StatusResponse {
-            #[serde(default)]
-            scheduled_maintenances: Vec<Maintenance>,
-        }
-
-        let status: StatusResponse = self
-            .fire(Request {
+    pub async fn get_active_maintenances<T: DeserializeOwned>(&self) -> Result<Vec<T>> {
+        let status = self
+            .fire::<Value>(Request {
                 body: None,
                 multipart: None,
                 headers: None,
@@ -2314,9 +2310,14 @@ impl Http {
                 route: Route::StatusMaintenancesActive,
                 params: None,
             })
-            .await?;
+            .await?
+            .get_mut("scheduled_maintenances")
+            .map(Value::take);
 
-        Ok(status.scheduled_maintenances)
+        match status {
+            Some(status) => from_value(status).map_err(From::from),
+            None => Ok(vec![]),
+        }
     }
 
     /// Gets all the users that are banned in specific guild, with additional options for
@@ -2329,12 +2330,12 @@ impl Http {
     /// after the provided [`UserId`] wrapped by the [`UserPagination`].
     ///
     /// [`UserId`]: crate::model::id::UserId
-    pub async fn get_bans(
+    pub async fn get_bans<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         target: Option<UserPagination>,
         limit: Option<NonMaxU16>,
-    ) -> Result<Vec<Ban>> {
+    ) -> Result<Vec<T>> {
         let id_str;
         let limit_str;
         let mut params = ArrayVec::<_, 2>::new();
@@ -2377,7 +2378,11 @@ impl Http {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Ban Members]: Permissions::BAN_MEMBERS
-    pub async fn get_ban(&self, guild_id: GuildId, user_id: UserId) -> Result<Option<Ban>> {
+    pub async fn get_ban<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+        user_id: UserId,
+    ) -> Result<Option<T>> {
         let result = self
             .fire(Request {
                 body: None,
@@ -2402,7 +2407,7 @@ impl Http {
     }
 
     /// Gets all audit logs in a specific guild.
-    pub async fn get_audit_logs(
+    pub async fn get_audit_logs<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         action_type: Option<u16>,
@@ -2410,7 +2415,7 @@ impl Http {
         before: Option<AuditLogEntryId>,
         after: Option<AuditLogEntryId>,
         limit: Option<NonMaxU8>,
-    ) -> Result<AuditLogs> {
+    ) -> Result<T> {
         let (action_type_str, before_str, after_str, limit_str, user_id_str);
         let mut params = ArrayVec::<_, 4>::new();
         if let Some(action_type) = action_type {
@@ -2448,7 +2453,10 @@ impl Http {
     }
 
     /// Retrieves all auto moderation rules in a guild.
-    pub async fn get_automod_rules(&self, guild_id: GuildId) -> Result<Vec<AutoModRule>> {
+    pub async fn get_automod_rules<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+    ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2463,11 +2471,11 @@ impl Http {
     }
 
     /// Retrieves an auto moderation rule in a guild.
-    pub async fn get_automod_rule(
+    pub async fn get_automod_rule<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         rule_id: RuleId,
-    ) -> Result<AutoModRule> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2483,12 +2491,12 @@ impl Http {
     }
 
     /// Creates an auto moderation rule in a guild.
-    pub async fn create_automod_rule(
+    pub async fn create_automod_rule<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<AutoModRule> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -2503,13 +2511,13 @@ impl Http {
     }
 
     /// Retrieves an auto moderation rule in a guild.
-    pub async fn edit_automod_rule(
+    pub async fn edit_automod_rule<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         rule_id: RuleId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<AutoModRule> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -2546,7 +2554,7 @@ impl Http {
     }
 
     /// Gets current bot gateway.
-    pub async fn get_bot_gateway(&self) -> Result<BotGateway> {
+    pub async fn get_bot_gateway<T: DeserializeOwned>(&self) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2559,7 +2567,10 @@ impl Http {
     }
 
     /// Gets all invites for a channel.
-    pub async fn get_channel_invites(&self, channel_id: ChannelId) -> Result<Vec<Invite>> {
+    pub async fn get_channel_invites<T: DeserializeOwned>(
+        &self,
+        channel_id: ChannelId,
+    ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2574,10 +2585,10 @@ impl Http {
     }
 
     /// Gets all thread members for a thread.
-    pub async fn get_channel_thread_members(
+    pub async fn get_channel_thread_members<T: DeserializeOwned>(
         &self,
         thread_id: ThreadId,
-    ) -> Result<Vec<ThreadMember>> {
+    ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2592,7 +2603,10 @@ impl Http {
     }
 
     /// Gets all active threads from a guild.
-    pub async fn get_guild_active_threads(&self, guild_id: GuildId) -> Result<ThreadsData> {
+    pub async fn get_guild_active_threads<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2607,12 +2621,12 @@ impl Http {
     }
 
     /// Gets all archived public threads from a channel.
-    pub async fn get_channel_archived_public_threads(
+    pub async fn get_channel_archived_public_threads<T: DeserializeOwned>(
         &self,
         channel_id: ChannelId,
         before: Option<Timestamp>,
         limit: Option<u64>,
-    ) -> Result<ThreadsData> {
+    ) -> Result<T> {
         let (before_str, limit_str);
         let mut params = ArrayVec::<_, 2>::new();
         if let Some(before) = before {
@@ -2638,12 +2652,12 @@ impl Http {
     }
 
     /// Gets all archived private threads from a channel.
-    pub async fn get_channel_archived_private_threads(
+    pub async fn get_channel_archived_private_threads<T: DeserializeOwned>(
         &self,
         channel_id: ChannelId,
         before: Option<Timestamp>,
         limit: Option<u64>,
-    ) -> Result<ThreadsData> {
+    ) -> Result<T> {
         let (before_str, limit_str);
         let mut params = ArrayVec::<_, 2>::new();
         if let Some(before) = before {
@@ -2669,12 +2683,12 @@ impl Http {
     }
 
     /// Gets all archived private threads joined from a channel.
-    pub async fn get_channel_joined_archived_private_threads(
+    pub async fn get_channel_joined_archived_private_threads<T: DeserializeOwned>(
         &self,
         channel_id: ChannelId,
         before: Option<ChannelId>,
         limit: Option<u64>,
-    ) -> Result<ThreadsData> {
+    ) -> Result<T> {
         let (before_str, limit_str);
         let mut params = ArrayVec::<_, 2>::new();
         if let Some(before) = before {
@@ -2769,12 +2783,12 @@ impl Http {
         .await
     }
 
-    pub async fn get_thread_channel_member(
+    pub async fn get_thread_channel_member<T: DeserializeOwned>(
         &self,
         thread_id: ThreadId,
         user_id: UserId,
         with_member: bool,
-    ) -> Result<ThreadMember> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2790,7 +2804,10 @@ impl Http {
     }
 
     /// Retrieves the webhooks for the given [channel][`GuildChannel`]'s Id.
-    pub async fn get_channel_webhooks(&self, channel_id: ChannelId) -> Result<Vec<Webhook>> {
+    pub async fn get_channel_webhooks<T: DeserializeOwned>(
+        &self,
+        channel_id: ChannelId,
+    ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2805,7 +2822,10 @@ impl Http {
     }
 
     /// Gets channel information.
-    pub async fn get_channel(&self, channel_id: GenericChannelId) -> Result<Channel> {
+    pub async fn get_channel<T: DeserializeOwned>(
+        &self,
+        channel_id: GenericChannelId,
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2820,10 +2840,10 @@ impl Http {
     }
 
     /// Gets all channels in a guild.
-    pub async fn get_channels(
+    pub async fn get_channels<T: DeserializeOwned + ExtractKey<ChannelId>>(
         &self,
         guild_id: GuildId,
-    ) -> Result<ExtractMap<ChannelId, GuildChannel>> {
+    ) -> Result<ExtractMap<ChannelId, T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2838,7 +2858,10 @@ impl Http {
     }
 
     /// Gets a stage instance.
-    pub async fn get_stage_instance(&self, channel_id: ChannelId) -> Result<StageInstance> {
+    pub async fn get_stage_instance<T: DeserializeOwned>(
+        &self,
+        channel_id: ChannelId,
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2853,19 +2876,14 @@ impl Http {
     }
 
     /// Get a list of users that voted for this specific answer.
-    pub async fn get_poll_answer_voters(
+    pub async fn get_poll_answer_voters<T: DeserializeOwned>(
         &self,
         channel_id: GenericChannelId,
         message_id: MessageId,
         answer_id: AnswerId,
         after: Option<UserId>,
         limit: Option<u8>,
-    ) -> Result<Vec<User>> {
-        #[derive(Deserialize)]
-        struct VotersResponse {
-            users: Vec<User>,
-        }
-
+    ) -> Result<Vec<T>> {
         let (after_str, limit_str);
         let mut params = ArrayVec::<_, 2>::new();
         if let Some(after) = after {
@@ -2878,8 +2896,8 @@ impl Http {
             params.push(("limit", &limit_str));
         }
 
-        let resp: VotersResponse = self
-            .fire(Request {
+        let resp = self
+            .fire::<Value>(Request {
                 body: None,
                 multipart: None,
                 headers: None,
@@ -2891,16 +2909,19 @@ impl Http {
                 },
                 params: Some(&params),
             })
-            .await?;
+            .await?
+            .get_mut("users")
+            .map(Value::take)
+            .unwrap_or_default();
 
-        Ok(resp.users)
+        from_value(resp).map_err(From::from)
     }
 
-    pub async fn expire_poll(
+    pub async fn expire_poll<T: DeserializeOwned>(
         &self,
         channel_id: GenericChannelId,
         message_id: MessageId,
-    ) -> Result<Message> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2918,7 +2939,7 @@ impl Http {
     /// Gets information about the current application.
     ///
     /// **Note**: Only applications may use this endpoint.
-    pub async fn get_current_application_info(&self) -> Result<CurrentApplicationInfo> {
+    pub async fn get_current_application_info<T: DeserializeOwned>(&self) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2931,7 +2952,7 @@ impl Http {
     }
 
     /// Gets information about the user we're connected with.
-    pub async fn get_current_user(&self) -> Result<CurrentUser> {
+    pub async fn get_current_user<T: DeserializeOwned>(&self) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2944,7 +2965,7 @@ impl Http {
     }
 
     /// Gets all emojis of a guild.
-    pub async fn get_emojis(&self, guild_id: GuildId) -> Result<Vec<Emoji>> {
+    pub async fn get_emojis<T: DeserializeOwned>(&self, guild_id: GuildId) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2959,7 +2980,11 @@ impl Http {
     }
 
     /// Gets information about an emoji in a guild.
-    pub async fn get_emoji(&self, guild_id: GuildId, emoji_id: EmojiId) -> Result<Emoji> {
+    pub async fn get_emoji<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+        emoji_id: EmojiId,
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2975,15 +3000,9 @@ impl Http {
     }
 
     /// Gets all emojis for the current application.
-    pub async fn get_application_emojis(&self) -> Result<Vec<Emoji>> {
-        // Why, discord...
-        #[derive(Deserialize)]
-        struct ApplicationEmojis {
-            items: Vec<Emoji>,
-        }
-
-        let result: ApplicationEmojis = self
-            .fire(Request {
+    pub async fn get_application_emojis<T: DeserializeOwned>(&self) -> Result<Vec<T>> {
+        let result = self
+            .fire::<Value>(Request {
                 body: None,
                 multipart: None,
                 headers: None,
@@ -2993,13 +3012,16 @@ impl Http {
                 },
                 params: None,
             })
-            .await?;
+            .await?
+            .get_mut("items")
+            .map(Value::take)
+            .unwrap_or_default();
 
-        Ok(result.items)
+        from_value(result).map_err(From::from)
     }
 
     /// Gets information about an application emoji.
-    pub async fn get_application_emoji(&self, emoji_id: EmojiId) -> Result<Emoji> {
+    pub async fn get_application_emoji<T: DeserializeOwned>(&self, emoji_id: EmojiId) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3038,7 +3060,7 @@ impl Http {
 
     #[expect(clippy::too_many_arguments)]
     /// Gets all entitlements for the current app, active and expired.
-    pub async fn get_entitlements(
+    pub async fn get_entitlements<T: DeserializeOwned>(
         &self,
         user_id: Option<UserId>,
         sku_ids: Option<&[SkuId]>,
@@ -3047,7 +3069,7 @@ impl Http {
         limit: Option<NonMaxU8>,
         guild_id: Option<GuildId>,
         exclude_ended: Option<bool>,
-    ) -> Result<Vec<Entitlement>> {
+    ) -> Result<Vec<T>> {
         let (user_id_str, sku_ids_str, before_str, after_str, limit_str, guild_id_str, exclude_str);
         let mut params = ArrayVec::<_, 7>::new();
         if let Some(user_id) = user_id {
@@ -3093,7 +3115,7 @@ impl Http {
     }
 
     /// Gets current gateway.
-    pub async fn get_gateway(&self) -> Result<Gateway> {
+    pub async fn get_gateway<T: DeserializeOwned>(&self) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3106,7 +3128,7 @@ impl Http {
     }
 
     /// Fetches all of the global commands for your application.
-    pub async fn get_global_commands(&self) -> Result<Vec<Command>> {
+    pub async fn get_global_commands<T: DeserializeOwned>(&self) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3121,7 +3143,9 @@ impl Http {
     }
 
     /// Fetches all of the global commands for your application with localizations.
-    pub async fn get_global_commands_with_localizations(&self) -> Result<Vec<Command>> {
+    pub async fn get_global_commands_with_localizations<T: DeserializeOwned>(
+        &self,
+    ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3136,7 +3160,10 @@ impl Http {
     }
 
     /// Fetches a global commands for your application by its Id.
-    pub async fn get_global_command(&self, command_id: CommandId) -> Result<Command> {
+    pub async fn get_global_command<T: DeserializeOwned>(
+        &self,
+        command_id: CommandId,
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3152,7 +3179,7 @@ impl Http {
     }
 
     /// Gets guild information.
-    pub async fn get_guild(&self, guild_id: GuildId) -> Result<PartialGuild> {
+    pub async fn get_guild<T: DeserializeOwned>(&self, guild_id: GuildId) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3167,7 +3194,7 @@ impl Http {
     }
 
     /// Gets guild information with counts.
-    pub async fn get_guild_with_counts(&self, guild_id: GuildId) -> Result<PartialGuild> {
+    pub async fn get_guild_with_counts<T: DeserializeOwned>(&self, guild_id: GuildId) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3182,7 +3209,10 @@ impl Http {
     }
 
     /// Fetches all of the guild commands for your application for a specific guild.
-    pub async fn get_guild_commands(&self, guild_id: GuildId) -> Result<Vec<Command>> {
+    pub async fn get_guild_commands<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+    ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3199,10 +3229,10 @@ impl Http {
 
     /// Fetches all of the guild commands with localizations for your application for a specific
     /// guild.
-    pub async fn get_guild_commands_with_localizations(
+    pub async fn get_guild_commands_with_localizations<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-    ) -> Result<Vec<Command>> {
+    ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3218,11 +3248,11 @@ impl Http {
     }
 
     /// Fetches a guild command by its Id.
-    pub async fn get_guild_command(
+    pub async fn get_guild_command<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         command_id: CommandId,
-    ) -> Result<Command> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3239,10 +3269,10 @@ impl Http {
     }
 
     /// Fetches all of the guild commands permissions for your application for a specific guild.
-    pub async fn get_guild_commands_permissions(
+    pub async fn get_guild_commands_permissions<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-    ) -> Result<Vec<CommandPermissions>> {
+    ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3258,11 +3288,11 @@ impl Http {
     }
 
     /// Gives the guild command permission for your application for a specific guild.
-    pub async fn get_guild_command_permissions(
+    pub async fn get_guild_command_permissions<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         command_id: CommandId,
-    ) -> Result<CommandPermissions> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3279,7 +3309,7 @@ impl Http {
     }
 
     /// Gets a guild widget information.
-    pub async fn get_guild_widget(&self, guild_id: GuildId) -> Result<GuildWidget> {
+    pub async fn get_guild_widget<T: DeserializeOwned>(&self, guild_id: GuildId) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3294,7 +3324,7 @@ impl Http {
     }
 
     /// Gets a guild preview.
-    pub async fn get_guild_preview(&self, guild_id: GuildId) -> Result<GuildPreview> {
+    pub async fn get_guild_preview<T: DeserializeOwned>(&self, guild_id: GuildId) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3309,7 +3339,10 @@ impl Http {
     }
 
     /// Gets a guild welcome screen information.
-    pub async fn get_guild_welcome_screen(&self, guild_id: GuildId) -> Result<GuildWelcomeScreen> {
+    pub async fn get_guild_welcome_screen<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3324,7 +3357,10 @@ impl Http {
     }
 
     /// Gets integrations that a guild has.
-    pub async fn get_guild_integrations(&self, guild_id: GuildId) -> Result<Vec<Integration>> {
+    pub async fn get_guild_integrations<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+    ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3339,7 +3375,10 @@ impl Http {
     }
 
     /// Gets all invites to a guild.
-    pub async fn get_guild_invites(&self, guild_id: GuildId) -> Result<Vec<Invite>> {
+    pub async fn get_guild_invites<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+    ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3354,34 +3393,34 @@ impl Http {
     }
 
     /// Gets a guild's vanity URL if it has one.
-    pub async fn get_guild_vanity_url(&self, guild_id: GuildId) -> Result<String> {
-        #[derive(Deserialize)]
-        struct GuildVanityUrl {
-            code: String,
-        }
+    pub async fn get_guild_vanity_url<T: DeserializeOwned>(&self, guild_id: GuildId) -> Result<T> {
+        let resp = self
+            .fire::<Value>(Request {
+                body: None,
+                multipart: None,
+                headers: None,
+                method: LightMethod::Get,
+                route: Route::GuildVanityUrl {
+                    guild_id,
+                },
+                params: None,
+            })
+            .await?
+            .get_mut("code")
+            .map(Value::take)
+            .unwrap_or_default();
 
-        self.fire(Request {
-            body: None,
-            multipart: None,
-            headers: None,
-            method: LightMethod::Get,
-            route: Route::GuildVanityUrl {
-                guild_id,
-            },
-            params: None,
-        })
-        .await
-        .map(|x: GuildVanityUrl| x.code)
+        from_value(resp).map_err(From::from)
     }
 
     /// Gets the members of a guild. Optionally pass a `limit` and the Id of the user to offset the
     /// result by.
-    pub async fn get_guild_members(
+    pub async fn get_guild_members<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         limit: Option<NonMaxU16>,
         after: Option<UserId>,
-    ) -> Result<Vec<Member>> {
+    ) -> Result<Vec<T>> {
         let (limit_str, after_str);
         let mut params = ArrayVec::<_, 2>::new();
 
@@ -3418,7 +3457,11 @@ impl Http {
     }
 
     /// Gets the amount of users that can be pruned.
-    pub async fn get_guild_prune_count(&self, guild_id: GuildId, days: u8) -> Result<GuildPrune> {
+    pub async fn get_guild_prune_count<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+        days: u8,
+    ) -> Result<T> {
         let days_str = days.to_arraystring();
         self.fire(Request {
             body: None,
@@ -3435,7 +3478,10 @@ impl Http {
 
     /// Gets regions that a guild can use. If a guild has the `VIP_REGIONS` feature enabled, then
     /// additional VIP-only regions are returned.
-    pub async fn get_guild_regions(&self, guild_id: GuildId) -> Result<Vec<VoiceRegion>> {
+    pub async fn get_guild_regions<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+    ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3450,7 +3496,11 @@ impl Http {
     }
 
     /// Retrieves a specific role in a [`Guild`].
-    pub async fn get_guild_role(&self, guild_id: GuildId, role_id: RoleId) -> Result<Role> {
+    pub async fn get_guild_role<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+        role_id: RoleId,
+    ) -> Result<T> {
         let mut value: Value = self
             .fire(Request {
                 body: None,
@@ -3494,7 +3544,10 @@ impl Http {
     }
 
     /// Retrieves a list of roles in a [`Guild`].
-    pub async fn get_guild_roles(&self, guild_id: GuildId) -> Result<ExtractMap<RoleId, Role>> {
+    pub async fn get_guild_roles<T: DeserializeOwned + ExtractKey<RoleId>>(
+        &self,
+        guild_id: GuildId,
+    ) -> Result<ExtractMap<RoleId, T>> {
         let mut value: Value = self
             .fire(Request {
                 body: None,
@@ -3520,12 +3573,12 @@ impl Http {
     }
 
     /// Gets a scheduled event by Id.
-    pub async fn get_scheduled_event(
+    pub async fn get_scheduled_event<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         event_id: ScheduledEventId,
         with_user_count: bool,
-    ) -> Result<ScheduledEvent> {
+    ) -> Result<T> {
         let with_user_count_str = with_user_count.to_arraystring();
         self.fire(Request {
             body: None,
@@ -3542,11 +3595,11 @@ impl Http {
     }
 
     /// Gets a list of all scheduled events for the corresponding guild.
-    pub async fn get_scheduled_events(
+    pub async fn get_scheduled_events<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         with_user_count: bool,
-    ) -> Result<Vec<ScheduledEvent>> {
+    ) -> Result<Vec<T>> {
         let with_user_count_str = with_user_count.to_arraystring();
         self.fire(Request {
             body: None,
@@ -3563,14 +3616,14 @@ impl Http {
 
     /// Gets a list of all interested users for the corresponding scheduled event, with additional
     /// options for filtering.
-    pub async fn get_scheduled_event_users(
+    pub async fn get_scheduled_event_users<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         event_id: ScheduledEventId,
         limit: Option<NonMaxU8>,
         target: Option<UserPagination>,
         with_member: Option<bool>,
-    ) -> Result<Vec<ScheduledEventUser>> {
+    ) -> Result<Vec<T>> {
         let (limit_str, with_member_str, id_str);
         let mut params = ArrayVec::<_, 3>::new();
         if let Some(limit) = limit {
@@ -3606,7 +3659,10 @@ impl Http {
     }
 
     /// Retrieves a list of stickers in a [`Guild`].
-    pub async fn get_guild_stickers(&self, guild_id: GuildId) -> Result<Vec<Sticker>> {
+    pub async fn get_guild_stickers<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+    ) -> Result<Vec<T>> {
         let mut value: Value = self
             .fire(Request {
                 body: None,
@@ -3632,11 +3688,11 @@ impl Http {
     }
 
     /// Retrieves a single sticker in a [`Guild`].
-    pub async fn get_guild_sticker(
+    pub async fn get_guild_sticker<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         sticker_id: StickerId,
-    ) -> Result<Sticker> {
+    ) -> Result<T> {
         let mut value: Value = self
             .fire(Request {
                 body: None,
@@ -3659,7 +3715,10 @@ impl Http {
     }
 
     /// Retrieves the webhooks for the given [`Guild`]'s Id.
-    pub async fn get_guild_webhooks(&self, guild_id: GuildId) -> Result<Vec<Webhook>> {
+    pub async fn get_guild_webhooks<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+    ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3676,11 +3735,11 @@ impl Http {
     /// Gets a paginated list of the current user's guilds.
     ///
     /// The `limit` has a maximum value of 200.
-    pub async fn get_guilds(
+    pub async fn get_guilds<T: DeserializeOwned>(
         &self,
         target: Option<GuildPagination>,
         limit: Option<NonMaxU8>,
-    ) -> Result<Vec<GuildInfo>> {
+    ) -> Result<Vec<T>> {
         let (limit_str, id_str);
         let mut params = ArrayVec::<_, 2>::new();
         if let Some(limit) = limit {
@@ -3713,7 +3772,10 @@ impl Http {
     /// This method only works for user tokens with the [`GuildsMembersRead`] OAuth2 scope.
     ///
     /// [`GuildsMembersRead`]: crate::model::application::Scope::GuildsMembersRead
-    pub async fn get_current_user_guild_member(&self, guild_id: GuildId) -> Result<Member> {
+    pub async fn get_current_user_guild_member<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+    ) -> Result<T> {
         let mut value: Value = self
             .fire(Request {
                 body: None,
@@ -3735,12 +3797,12 @@ impl Http {
     }
 
     /// Gets information about a specific invite.
-    pub async fn get_invite(
+    pub async fn get_invite<T: DeserializeOwned>(
         &self,
         code: &str,
         member_counts: bool,
         event_id: Option<ScheduledEventId>,
-    ) -> Result<Invite> {
+    ) -> Result<T> {
         let (member_counts_str, event_id_str);
         let mut params = ArrayVec::<_, 2>::new();
 
@@ -3766,7 +3828,11 @@ impl Http {
     }
 
     /// Gets member of a guild.
-    pub async fn get_member(&self, guild_id: GuildId, user_id: UserId) -> Result<Member> {
+    pub async fn get_member<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+        user_id: UserId,
+    ) -> Result<T> {
         let mut value: Value = self
             .fire(Request {
                 body: None,
@@ -3789,11 +3855,11 @@ impl Http {
     }
 
     /// Gets a message by an Id, bots only.
-    pub async fn get_message(
+    pub async fn get_message<T: DeserializeOwned>(
         &self,
         channel_id: GenericChannelId,
         message_id: MessageId,
-    ) -> Result<Message> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3809,12 +3875,12 @@ impl Http {
     }
 
     /// Gets X messages from a channel.
-    pub async fn get_messages(
+    pub async fn get_messages<T: DeserializeOwned>(
         &self,
         channel_id: GenericChannelId,
         target: Option<MessagePagination>,
         limit: Option<NonMaxU8>,
-    ) -> Result<Vec<Message>> {
+    ) -> Result<Vec<T>> {
         let (limit_str, id_str);
         let mut params = ArrayVec::<_, 2>::new();
 
@@ -3848,7 +3914,10 @@ impl Http {
     }
 
     /// Retrieves a specific [`StickerPack`] from it's [`StickerPackId`]
-    pub async fn get_sticker_pack(&self, sticker_pack_id: StickerPackId) -> Result<StickerPack> {
+    pub async fn get_sticker_pack<T: DeserializeOwned>(
+        &self,
+        sticker_pack_id: StickerPackId,
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3863,31 +3932,31 @@ impl Http {
     }
 
     /// Retrieves a list of all nitro sticker packs.
-    pub async fn get_nitro_stickers(&self) -> Result<Vec<StickerPack>> {
-        #[derive(Deserialize)]
-        struct StickerPacks {
-            sticker_packs: Vec<StickerPack>,
-        }
+    pub async fn get_nitro_stickers<T: DeserializeOwned>(&self) -> Result<Vec<T>> {
+        let resp = self
+            .fire::<Value>(Request {
+                body: None,
+                multipart: None,
+                headers: None,
+                method: LightMethod::Get,
+                route: Route::StickerPacks,
+                params: None,
+            })
+            .await?
+            .get_mut("sticker_packs")
+            .map(Value::take)
+            .unwrap_or_default();
 
-        self.fire(Request {
-            body: None,
-            multipart: None,
-            headers: None,
-            method: LightMethod::Get,
-            route: Route::StickerPacks,
-            params: None,
-        })
-        .await
-        .map(|s: StickerPacks| s.sticker_packs)
+        from_value(resp).map_err(From::from)
     }
 
     /// Gets all pins of a channel.
-    pub async fn get_pins(
+    pub async fn get_pins<T: DeserializeOwned>(
         &self,
         channel_id: GenericChannelId,
         before: Option<Timestamp>,
         limit: Option<u8>,
-    ) -> Result<MessagePinsPage> {
+    ) -> Result<T> {
         let (before_str, limit_str);
         let mut params = ArrayVec::<_, 2>::new();
 
@@ -3915,7 +3984,7 @@ impl Http {
     }
 
     /// Gets a list of users who reacted with an emoji.
-    pub async fn get_reaction_users(
+    pub async fn get_reaction_users<T: DeserializeOwned>(
         &self,
         channel_id: GenericChannelId,
         message_id: MessageId,
@@ -3923,7 +3992,7 @@ impl Http {
         reaction_type: Option<ReactionTypes>,
         limit: Option<NonMaxU8>,
         after: Option<UserId>,
-    ) -> Result<Vec<User>> {
+    ) -> Result<Vec<T>> {
         let (type_str, limit_str, after_str);
         let mut params = ArrayVec::<_, 3>::new();
 
@@ -3958,7 +4027,7 @@ impl Http {
     }
 
     /// Gets all SKUs for the current application.
-    pub async fn get_skus(&self) -> Result<Vec<Sku>> {
+    pub async fn get_skus<T: DeserializeOwned>(&self) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3973,7 +4042,7 @@ impl Http {
     }
 
     /// Gets a sticker.
-    pub async fn get_sticker(&self, sticker_id: StickerId) -> Result<Sticker> {
+    pub async fn get_sticker<T: DeserializeOwned>(&self, sticker_id: StickerId) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3990,15 +4059,9 @@ impl Http {
     /// Gets the current unresolved incidents from Discord's Status API.
     ///
     /// Does not require authentication.
-    pub async fn get_unresolved_incidents(&self) -> Result<Vec<Incident>> {
-        #[derive(Deserialize)]
-        struct StatusResponse {
-            #[serde(default)]
-            incidents: Vec<Incident>,
-        }
-
-        let status: StatusResponse = self
-            .fire(Request {
+    pub async fn get_unresolved_incidents<T: DeserializeOwned>(&self) -> Result<Vec<T>> {
+        let status = self
+            .fire::<Value>(Request {
                 body: None,
                 multipart: None,
                 headers: None,
@@ -4006,23 +4069,22 @@ impl Http {
                 route: Route::StatusIncidentsUnresolved,
                 params: None,
             })
-            .await?;
+            .await?
+            .get_mut("incidents")
+            .map(Value::take);
 
-        Ok(status.incidents)
+        match status {
+            Some(status) => from_value(status).map_err(From::from),
+            None => Ok(vec![]),
+        }
     }
 
     /// Gets the upcoming (planned) maintenances from Discord's Status API.
     ///
     /// Does not require authentication.
-    pub async fn get_upcoming_maintenances(&self) -> Result<Vec<Maintenance>> {
-        #[derive(Deserialize)]
-        struct StatusResponse {
-            #[serde(default)]
-            scheduled_maintenances: Vec<Maintenance>,
-        }
-
-        let status: StatusResponse = self
-            .fire(Request {
+    pub async fn get_upcoming_maintenances<T: DeserializeOwned>(&self) -> Result<Vec<T>> {
+        let status = self
+            .fire::<Value>(Request {
                 body: None,
                 multipart: None,
                 headers: None,
@@ -4030,13 +4092,18 @@ impl Http {
                 route: Route::StatusMaintenancesUpcoming,
                 params: None,
             })
-            .await?;
+            .await?
+            .get_mut("scheduled_maintenances")
+            .map(Value::take);
 
-        Ok(status.scheduled_maintenances)
+        match status {
+            Some(status) => from_value(status).map_err(From::from),
+            None => Ok(vec![]),
+        }
     }
 
     /// Gets a user by Id.
-    pub async fn get_user(&self, user_id: UserId) -> Result<User> {
+    pub async fn get_user<T: DeserializeOwned>(&self, user_id: UserId) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -4055,7 +4122,7 @@ impl Http {
     /// This method only works for user tokens with the [`Connections`] OAuth2 scope.
     ///
     /// [`Connections`]: crate::model::application::Scope::Connections
-    pub async fn get_user_connections(&self) -> Result<Vec<Connection>> {
+    pub async fn get_user_connections<T: DeserializeOwned>(&self) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -4068,7 +4135,7 @@ impl Http {
     }
 
     /// Gets our DM channels.
-    pub async fn get_user_dm_channels(&self) -> Result<Vec<PrivateChannel>> {
+    pub async fn get_user_dm_channels<T: DeserializeOwned>(&self) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -4081,7 +4148,7 @@ impl Http {
     }
 
     /// Gets all voice regions.
-    pub async fn get_voice_regions(&self) -> Result<Vec<VoiceRegion>> {
+    pub async fn get_voice_regions<T: DeserializeOwned>(&self) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -4095,11 +4162,11 @@ impl Http {
 
     /// Get User Voice State
     /// Returns the specified user's voice state in the guild.
-    pub async fn get_user_voice_state(
+    pub async fn get_user_voice_state<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         user_id: UserId,
-    ) -> Result<VoiceState> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -4118,7 +4185,7 @@ impl Http {
     ///
     /// This method requires authentication, whereas [`Http::get_webhook_with_token`] and
     /// [`Http::get_webhook_from_url`] do not.
-    pub async fn get_webhook(&self, webhook_id: WebhookId) -> Result<Webhook> {
+    pub async fn get_webhook<T: DeserializeOwned>(&self, webhook_id: WebhookId) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -4135,11 +4202,11 @@ impl Http {
     /// Retrieves a webhook given its Id and unique token.
     ///
     /// This method does _not_ require authentication.
-    pub async fn get_webhook_with_token(
+    pub async fn get_webhook_with_token<T: DeserializeOwned>(
         &self,
         webhook_id: WebhookId,
         token: &str,
-    ) -> Result<Webhook> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -4158,7 +4225,7 @@ impl Http {
     ///
     /// This method does _not_ require authentication
     #[cfg(feature = "utils")]
-    pub async fn get_webhook_from_url(&self, url: &str) -> Result<Webhook> {
+    pub async fn get_webhook_from_url<T: DeserializeOwned>(&self, url: &str) -> Result<T> {
         let url = Url::parse(url)?;
         let (webhook_id, token) =
             crate::utils::parse_webhook(&url).ok_or(HttpError::InvalidWebhook)?;
@@ -4213,12 +4280,12 @@ impl Http {
     }
 
     /// Sends a message to a channel.
-    pub async fn send_message(
+    pub async fn send_message<T: DeserializeOwned>(
         &self,
         channel_id: GenericChannelId,
         files: Vec<AttachmentData<'_>>,
-        map: &impl serde::Serialize,
-    ) -> Result<Message> {
+        map: &impl Serialize,
+    ) -> Result<T> {
         let mut request = Request {
             body: None,
             multipart: None,
@@ -4310,12 +4377,12 @@ impl Http {
 
     /// Returns a list of [`Member`]s in a [`Guild`] whose username or nickname starts with a
     /// provided string.
-    pub async fn search_guild_members(
+    pub async fn search_guild_members<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         query: &str,
         limit: Option<NonMaxU16>,
-    ) -> Result<Vec<Member>> {
+    ) -> Result<Vec<T>> {
         let limit_str = limit.unwrap_or(constants::MEMBER_FETCH_LIMIT).get().to_arraystring();
         let mut value: Value = self
             .fire(Request {
@@ -4342,12 +4409,12 @@ impl Http {
     }
 
     /// Starts removing some members from a guild based on the last time they've been online.
-    pub async fn start_guild_prune(
+    pub async fn start_guild_prune<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         days: u8,
         audit_log_reason: Option<&str>,
-    ) -> Result<GuildPrune> {
+    ) -> Result<T> {
         let days_str = days.to_arraystring();
         self.fire(Request {
             body: None,
@@ -4387,11 +4454,11 @@ impl Http {
     /// **Note**: Requires the [Manage Guild] permission.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn edit_guild_incident_actions(
+    pub async fn edit_guild_incident_actions<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
-    ) -> Result<IncidentsData> {
+        map: &impl Serialize,
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -4430,7 +4497,7 @@ impl Http {
     pub async fn send_soundboard_sound(
         &self,
         channel_id: ChannelId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
     ) -> Result<()> {
         self.wind(Request {
             body: Some(to_vec(map)?),
@@ -4446,7 +4513,7 @@ impl Http {
     }
 
     /// Retrieves a list of soundboard sounds that anyone can use.
-    pub async fn list_default_soundboard_sounds(&self) -> Result<Vec<Soundboard>> {
+    pub async fn list_default_soundboard_sounds<T: DeserializeOwned>(&self) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -4459,14 +4526,12 @@ impl Http {
     }
 
     /// Retrieves soundboard sounds from a guild.
-    pub async fn get_guild_soundboards(&self, guild_id: GuildId) -> Result<Vec<Soundboard>> {
-        #[derive(serde::Deserialize)]
-        struct SoundboardList {
-            items: Vec<Soundboard>,
-        }
-
-        let result: SoundboardList = self
-            .fire(Request {
+    pub async fn get_guild_soundboards<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+    ) -> Result<Vec<T>> {
+        let result = self
+            .fire::<Value>(Request {
                 body: None,
                 multipart: None,
                 headers: None,
@@ -4476,17 +4541,20 @@ impl Http {
                 },
                 params: None,
             })
-            .await?;
+            .await?
+            .get_mut("items")
+            .map(Value::take)
+            .unwrap_or_default();
 
-        Ok(result.items)
+        from_value(result).map_err(From::from)
     }
 
     /// Retrieves a soundboard sound from a guild.
-    pub async fn get_guild_soundboard(
+    pub async fn get_guild_soundboard<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         sound_id: SoundId,
-    ) -> Result<Soundboard> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -4502,12 +4570,12 @@ impl Http {
     }
 
     /// Creates a soundboard sound in a guild.
-    pub async fn create_guild_soundboard(
+    pub async fn create_guild_soundboard<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<Soundboard> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -4522,13 +4590,13 @@ impl Http {
     }
 
     /// Edits a soundboard sound in a guild.
-    pub async fn edit_guild_soundboard(
+    pub async fn edit_guild_soundboard<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         sound_id: SoundId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<Soundboard> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -75,7 +75,7 @@ impl ChannelId {
             }
         }
 
-        let channel = cache_http.http().get_channel(self.widen()).await?;
+        let channel: Channel = cache_http.http().get_channel(self.widen()).await?;
         let guild_channel = channel.guild().ok_or(ModelError::InvalidChannelType)?;
 
         #[cfg(all(feature = "cache", feature = "temp_cache"))]
@@ -722,7 +722,7 @@ impl GenericChannelId {
             return Ok(message.clone());
         }
 
-        let message = cache_http.http().get_message(self, message_id).await?;
+        let message: Message = cache_http.http().get_message(self, message_id).await?;
 
         #[cfg(feature = "temp_cache")]
         if let Some(cache) = cache_http.cache() {
@@ -821,7 +821,7 @@ impl GenericChannelId {
         before: Option<Timestamp>,
         limit: Option<u8>,
     ) -> Result<MessagePinsPage> {
-        let page = cache_http.http().get_pins(self, before, limit).await?;
+        let page: MessagePinsPage = cache_http.http().get_pins(self, before, limit).await?;
 
         #[cfg(feature = "cache")]
         if let Some(cache) = cache_http.cache() {

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -592,7 +592,7 @@ impl Message {
             }
         }
 
-        let current_user = cache_http.http().get_current_user().await?;
+        let current_user: CurrentUser = cache_http.http().get_current_user().await?;
         Ok(self.mentions_user_id(current_user.id))
     }
 
@@ -642,7 +642,8 @@ impl Message {
             return channel.parent_id;
         }
 
-        cache_http.http().get_channel(self.channel_id).await.ok()?.guild()?.parent_id
+        let channel: Channel = cache_http.http().get_channel(self.channel_id).await.ok()?;
+        channel.guild()?.parent_id
     }
 }
 

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -174,7 +174,8 @@ impl Reaction {
                 }
             }
 
-            Ok(cache_http.http().get_current_user().await?.into())
+            let current_user: CurrentUser = cache_http.http().get_current_user().await?;
+            Ok(current_user.into())
         }
     }
 

--- a/src/model/channel/thread.rs
+++ b/src/model/channel/thread.rs
@@ -51,7 +51,7 @@ impl ThreadId {
             }
         }
 
-        let channel = cache_http.http().get_channel(self.widen()).await?;
+        let channel: Channel = cache_http.http().get_channel(self.widen()).await?;
         let guild_thread = channel.thread().ok_or(ModelError::InvalidChannelType)?;
 
         #[cfg(all(feature = "cache", feature = "temp_cache"))]

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -672,7 +672,7 @@ impl UserId {
             recipient_id: self,
         };
 
-        let channel = cache_http.http().create_private_channel(&body).await?;
+        let channel: PrivateChannel = cache_http.http().create_private_channel(&body).await?;
 
         #[cfg(feature = "temp_cache")]
         if let Some(cache) = cache_http.cache() {
@@ -758,7 +758,7 @@ impl UserId {
             }
         }
 
-        let user = cache_http.http().get_user(self).await?;
+        let user: User = cache_http.http().get_user(self).await?;
 
         #[cfg(feature = "temp_cache")]
         {


### PR DESCRIPTION
The first of two PRs for preparing serenity to be split into multiple crates. Replaces the return type for http API methods with a generic `T: DeserializeOwned`.

This removes the `http` module's dependency on most model types by having the caller decide the concrete type for deserialization. This makes these methods less useful by themselves unless you know what exactly you're deserializing into, however this does mean that if Discord adds a new field to a response, users can define their own type for deserialization rather than waiting for serenity to add support or modifying the library themselves.