### PR TITLE
Rename `InnerId` to `Snowflake` and replace all other Id types in `http` with it

### DIFF
--- a/src/builder/add_member.rs
+++ b/src/builder/add_member.rs
@@ -96,6 +96,6 @@ impl<'a> AddMember<'a> {
         guild_id: GuildId,
         user_id: UserId,
     ) -> Result<Option<Member>> {
-        http.add_guild_member(guild_id, user_id, &self).await
+        http.add_guild_member(guild_id.0, user_id.0, &self).await
     }
 }

--- a/src/builder/bot_auth_parameters.rs
+++ b/src/builder/bot_auth_parameters.rs
@@ -86,7 +86,8 @@ impl<'a> CreateBotAuthParameters<'a> {
     /// [`HttpError::UnsuccessfulRequest`]: crate::http::HttpError::UnsuccessfulRequest
     #[cfg(feature = "http")]
     pub async fn auto_client_id(mut self, http: &Http) -> Result<Self> {
-        self.client_id = http.get_current_application_info().await.map(|v| Some(v.id))?;
+        let info: CurrentApplicationInfo = http.get_current_application_info().await?;
+        self.client_id = Some(info.id);
         Ok(self)
     }
 

--- a/src/builder/create_channel.rs
+++ b/src/builder/create_channel.rs
@@ -308,6 +308,6 @@ impl<'a> CreateChannel<'a> {
     /// [Manage Roles]: Permissions::MANAGE_ROLES
     #[cfg(feature = "http")]
     pub async fn execute(self, http: &Http, guild_id: GuildId) -> Result<GuildChannel> {
-        http.create_channel(guild_id, &self, self.audit_log_reason).await
+        http.create_channel(guild_id.0, &self, self.audit_log_reason).await
     }
 }

--- a/src/builder/create_command.rs
+++ b/src/builder/create_command.rs
@@ -491,7 +491,7 @@ impl<'a> CreateCommand<'a> {
     #[cfg(feature = "http")]
     pub async fn execute(self, http: &Http, guild_id: Option<GuildId>) -> Result<Command> {
         match guild_id {
-            Some(guild_id) => http.create_guild_command(guild_id, &self).await,
+            Some(guild_id) => http.create_guild_command(guild_id.0, &self).await,
             None => http.create_global_command(&self).await,
         }
     }

--- a/src/builder/create_command_permission.rs
+++ b/src/builder/create_command_permission.rs
@@ -42,7 +42,7 @@ impl<'a> EditCommandPermissions<'a> {
         guild_id: GuildId,
         command_id: CommandId,
     ) -> Result<CommandPermissions> {
-        http.edit_guild_command_permissions(guild_id, command_id, &self).await
+        http.edit_guild_command_permissions(guild_id.0, command_id.0, &self).await
     }
 }
 

--- a/src/builder/create_forum_post.rs
+++ b/src/builder/create_forum_post.rs
@@ -98,6 +98,6 @@ impl<'a> CreateForumPost<'a> {
     #[cfg(feature = "http")]
     pub async fn execute(self, http: &Http, channel_id: ChannelId) -> Result<GuildThread> {
         let files = self.message.attachments.new_attachment_data();
-        http.create_forum_post(channel_id, &self, files, self.audit_log_reason).await
+        http.create_forum_post(channel_id.0, &self, files, self.audit_log_reason).await
     }
 }

--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -144,7 +144,7 @@ impl CreateInteractionResponse<'_> {
             msg.allowed_mentions.clone_from(&http.default_allowed_mentions);
         }
 
-        http.create_interaction_response(interaction_id, interaction_token, &self, files).await
+        http.create_interaction_response(interaction_id.0, interaction_token, &self, files).await
     }
 }
 
@@ -418,7 +418,8 @@ impl<'a> CreateAutocompleteResponse<'a> {
         interaction_id: InteractionId,
         interaction_token: &str,
     ) -> Result<()> {
-        http.create_interaction_response(interaction_id, interaction_token, &self, Vec::new()).await
+        http.create_interaction_response(interaction_id.0, interaction_token, &self, Vec::new())
+            .await
     }
 }
 

--- a/src/builder/create_interaction_response_followup.rs
+++ b/src/builder/create_interaction_response_followup.rs
@@ -185,7 +185,7 @@ impl<'a> CreateInteractionResponseFollowup<'a> {
         }
 
         match message_id {
-            Some(id) => http.edit_followup_message(interaction_token, id, &self, files).await,
+            Some(id) => http.edit_followup_message(interaction_token, id.0, &self, files).await,
             None => http.create_followup_message(interaction_token, &self, files).await,
         }
     }

--- a/src/builder/create_invite.rs
+++ b/src/builder/create_invite.rs
@@ -140,6 +140,6 @@ impl<'a> CreateInvite<'a> {
     /// [Create Instant Invite]: Permissions::CREATE_INSTANT_INVITE
     #[cfg(feature = "http")]
     pub async fn execute(self, http: &Http, channel_id: ChannelId) -> Result<Invite> {
-        http.create_invite(channel_id, &self, self.audit_log_reason).await
+        http.create_invite(channel_id.0, &self, self.audit_log_reason).await
     }
 }

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -284,6 +284,6 @@ impl<'a> CreateMessage<'a> {
             self.allowed_mentions.clone_from(&http.default_allowed_mentions);
         }
 
-        http.send_message(channel_id, files, &self).await
+        http.send_message(channel_id.0, files, &self).await
     }
 }

--- a/src/builder/create_scheduled_event.rs
+++ b/src/builder/create_scheduled_event.rs
@@ -130,7 +130,7 @@ impl<'a> CreateScheduledEvent<'a> {
     /// [Create Events]: Permissions::CREATE_EVENTS
     #[cfg(feature = "http")]
     pub async fn execute(self, http: &Http, guild_id: GuildId) -> Result<ScheduledEvent> {
-        http.create_scheduled_event(guild_id, &self, self.audit_log_reason).await
+        http.create_scheduled_event(guild_id.0, &self, self.audit_log_reason).await
     }
 }
 

--- a/src/builder/create_soundboard.rs
+++ b/src/builder/create_soundboard.rs
@@ -92,6 +92,6 @@ impl<'a> CreateSoundboard<'a> {
         cache_http: impl CacheHttp,
         guild_id: GuildId,
     ) -> Result<Soundboard> {
-        cache_http.http().create_guild_soundboard(guild_id, &self, self.audit_log_reason).await
+        cache_http.http().create_guild_soundboard(guild_id.0, &self, self.audit_log_reason).await
     }
 }

--- a/src/builder/create_sticker.rs
+++ b/src/builder/create_sticker.rs
@@ -86,6 +86,6 @@ impl<'a> CreateSticker<'a> {
             ("description".into(), self.description),
         ];
 
-        http.create_sticker(guild_id, map, self.file.into(), self.audit_log_reason).await
+        http.create_sticker(guild_id.0, map, self.file.into(), self.audit_log_reason).await
     }
 }

--- a/src/builder/create_thread.rs
+++ b/src/builder/create_thread.rs
@@ -108,9 +108,10 @@ impl<'a> CreateThread<'a> {
     ) -> Result<GuildThread> {
         match message_id {
             Some(id) => {
-                http.create_thread_from_message(channel_id, id, &self, self.audit_log_reason).await
+                http.create_thread_from_message(channel_id.0, id.0, &self, self.audit_log_reason)
+                    .await
             },
-            None => http.create_thread(channel_id, &self, self.audit_log_reason).await,
+            None => http.create_thread(channel_id.0, &self, self.audit_log_reason).await,
         }
     }
 }

--- a/src/builder/create_webhook.rs
+++ b/src/builder/create_webhook.rs
@@ -65,6 +65,6 @@ impl<'a> CreateWebhook<'a> {
         crate::model::error::Minimum::WebhookName.check_underflow(self.name.chars().count())?;
         crate::model::error::Maximum::WebhookName.check_overflow(self.name.chars().count())?;
 
-        http.create_webhook(channel_id, &self, self.audit_log_reason).await
+        http.create_webhook(channel_id.0, &self, self.audit_log_reason).await
     }
 }

--- a/src/builder/edit_automod_rule.rs
+++ b/src/builder/edit_automod_rule.rs
@@ -113,10 +113,12 @@ impl<'a> EditAutoModRule<'a> {
         rule_id: Option<RuleId>,
     ) -> Result<AutoModRule> {
         match rule_id {
-            Some(id) => http.edit_automod_rule(guild_id, id, &self, self.audit_log_reason).await,
+            Some(id) => {
+                http.edit_automod_rule(guild_id.0, id.0, &self, self.audit_log_reason).await
+            },
             // Automod Rule creation has required fields, whereas modifying a rule does not.
             // TODO: Enforce these fields (maybe with a separate CreateAutoModRule builder).
-            None => http.create_automod_rule(guild_id, &self, self.audit_log_reason).await,
+            None => http.create_automod_rule(guild_id.0, &self, self.audit_log_reason).await,
         }
     }
 }

--- a/src/builder/edit_channel.rs
+++ b/src/builder/edit_channel.rs
@@ -339,9 +339,8 @@ impl<'a> EditChannel<'a> {
             .await?;
         }
 
-        http.edit_channel(channel_id.widen(), &self, self.audit_log_reason)
-            .await?
-            .guild()
-            .ok_or(Error::Model(ModelError::InvalidChannelType))
+        let channel: Channel =
+            http.edit_channel(channel_id.widen(), &self, self.audit_log_reason).await?;
+        channel.guild().ok_or(Error::Model(ModelError::InvalidChannelType))
     }
 }

--- a/src/builder/edit_channel.rs
+++ b/src/builder/edit_channel.rs
@@ -330,7 +330,7 @@ impl<'a> EditChannel<'a> {
             }
 
             http.edit_voice_status(
-                channel_id,
+                channel_id.0,
                 &EditVoiceStatusBody {
                     status,
                 },
@@ -340,7 +340,7 @@ impl<'a> EditChannel<'a> {
         }
 
         let channel: Channel =
-            http.edit_channel(channel_id.widen(), &self, self.audit_log_reason).await?;
+            http.edit_channel(channel_id.0, &self, self.audit_log_reason).await?;
         channel.guild().ok_or(Error::Model(ModelError::InvalidChannelType))
     }
 }

--- a/src/builder/edit_command.rs
+++ b/src/builder/edit_command.rs
@@ -172,8 +172,8 @@ impl<'a> EditCommand<'a> {
         guild_id: Option<GuildId>,
     ) -> Result<Command> {
         match guild_id {
-            Some(guild_id) => http.edit_guild_command(guild_id, command_id, &self).await,
-            None => http.edit_global_command(command_id, &self).await,
+            Some(guild_id) => http.edit_guild_command(guild_id.0, command_id.0, &self).await,
+            None => http.edit_global_command(command_id.0, &self).await,
         }
     }
 }

--- a/src/builder/edit_current_member.rs
+++ b/src/builder/edit_current_member.rs
@@ -79,6 +79,6 @@ impl<'a> EditCurrentMember<'a> {
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
     #[cfg(feature = "http")]
     pub async fn execute(self, http: &Http, guild_id: GuildId) -> Result<Member> {
-        http.edit_current_member(guild_id, &self, self.audit_log_reason).await
+        http.edit_current_member(guild_id.0, &self, self.audit_log_reason).await
     }
 }

--- a/src/builder/edit_guild.rs
+++ b/src/builder/edit_guild.rs
@@ -319,6 +319,6 @@ impl<'a> EditGuild<'a> {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     #[cfg(feature = "http")]
     pub async fn execute(self, http: &Http, guild_id: GuildId) -> Result<PartialGuild> {
-        http.edit_guild(guild_id, &self, self.audit_log_reason).await
+        http.edit_guild(guild_id.0, &self, self.audit_log_reason).await
     }
 }

--- a/src/builder/edit_guild_incident_actions.rs
+++ b/src/builder/edit_guild_incident_actions.rs
@@ -40,6 +40,6 @@ impl EditGuildIncidentActions {
     /// May also return [`Error::Json`] if there is an error in deserializing the API response.
     #[cfg(feature = "http")]
     pub async fn execute(self, http: &Http, guild_id: GuildId) -> Result<IncidentsData> {
-        http.edit_guild_incident_actions(guild_id, &self).await
+        http.edit_guild_incident_actions(guild_id.0, &self).await
     }
 }

--- a/src/builder/edit_guild_welcome_screen.rs
+++ b/src/builder/edit_guild_welcome_screen.rs
@@ -70,7 +70,7 @@ impl<'a> EditGuildWelcomeScreen<'a> {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     #[cfg(feature = "http")]
     pub async fn execute(self, http: &Http, guild_id: GuildId) -> Result<GuildWelcomeScreen> {
-        http.edit_guild_welcome_screen(guild_id, &self, self.audit_log_reason).await
+        http.edit_guild_welcome_screen(guild_id.0, &self, self.audit_log_reason).await
     }
 }
 

--- a/src/builder/edit_guild_widget.rs
+++ b/src/builder/edit_guild_widget.rs
@@ -52,6 +52,6 @@ impl<'a> EditGuildWidget<'a> {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     #[cfg(feature = "http")]
     pub async fn execute(self, http: &Http, guild_id: GuildId) -> Result<GuildWidget> {
-        http.edit_guild_widget(guild_id, &self, self.audit_log_reason).await
+        http.edit_guild_widget(guild_id.0, &self, self.audit_log_reason).await
     }
 }

--- a/src/builder/edit_member.rs
+++ b/src/builder/edit_member.rs
@@ -141,6 +141,6 @@ impl<'a> EditMember<'a> {
     /// Returns [`Error::Http`] if the current user lacks permission, or if invalid data is given.
     #[cfg(feature = "http")]
     pub async fn execute(self, http: &Http, guild_id: GuildId, user_id: UserId) -> Result<Member> {
-        http.edit_member(guild_id, user_id, &self, self.audit_log_reason).await
+        http.edit_member(guild_id.0, user_id.0, &self, self.audit_log_reason).await
     }
 }

--- a/src/builder/edit_message.rs
+++ b/src/builder/edit_message.rs
@@ -249,6 +249,6 @@ impl<'a> EditMessage<'a> {
             self.allowed_mentions.clone_from(&http.default_allowed_mentions);
         }
 
-        http.edit_message(channel_id, message_id, &self, files).await
+        http.edit_message(channel_id.0, message_id.0, &self, files).await
     }
 }

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -171,9 +171,9 @@ impl<'a> EditRole<'a> {
     ) -> Result<Role> {
         let role: Role = match role_id {
             Some(role_id) => {
-                http.edit_role(guild_id, role_id, &self, self.audit_log_reason).await?
+                http.edit_role(guild_id.0, role_id.0, &self, self.audit_log_reason).await?
             },
-            None => http.create_role(guild_id, &self, self.audit_log_reason).await?,
+            None => http.create_role(guild_id.0, &self, self.audit_log_reason).await?,
         };
 
         if let Some(position) = self.position {

--- a/src/builder/edit_role.rs
+++ b/src/builder/edit_role.rs
@@ -169,7 +169,7 @@ impl<'a> EditRole<'a> {
         guild_id: GuildId,
         role_id: Option<RoleId>,
     ) -> Result<Role> {
-        let role = match role_id {
+        let role: Role = match role_id {
             Some(role_id) => {
                 http.edit_role(guild_id, role_id, &self, self.audit_log_reason).await?
             },

--- a/src/builder/edit_scheduled_event.rs
+++ b/src/builder/edit_scheduled_event.rs
@@ -179,6 +179,6 @@ impl<'a> EditScheduledEvent<'a> {
         guild_id: GuildId,
         event_id: ScheduledEventId,
     ) -> Result<ScheduledEvent> {
-        http.edit_scheduled_event(guild_id, event_id, &self, self.audit_log_reason).await
+        http.edit_scheduled_event(guild_id.0, event_id.0, &self, self.audit_log_reason).await
     }
 }

--- a/src/builder/edit_soundboard.rs
+++ b/src/builder/edit_soundboard.rs
@@ -82,7 +82,7 @@ impl<'a> EditSoundboard<'a> {
     ) -> Result<Soundboard> {
         cache_http
             .http()
-            .edit_guild_soundboard(guild_id, sound_id, &self, self.audit_log_reason)
+            .edit_guild_soundboard(guild_id.0, sound_id.0, &self, self.audit_log_reason)
             .await
     }
 }

--- a/src/builder/edit_stage_instance.rs
+++ b/src/builder/edit_stage_instance.rs
@@ -51,6 +51,6 @@ impl<'a> EditStageInstance<'a> {
     /// instance currently.
     #[cfg(feature = "http")]
     pub async fn execute(self, http: &Http, channel_id: ChannelId) -> Result<StageInstance> {
-        http.edit_stage_instance(channel_id, &self, self.audit_log_reason).await
+        http.edit_stage_instance(channel_id.0, &self, self.audit_log_reason).await
     }
 }

--- a/src/builder/edit_sticker.rs
+++ b/src/builder/edit_sticker.rs
@@ -82,6 +82,6 @@ impl<'a> EditSticker<'a> {
         guild_id: GuildId,
         sticker_id: StickerId,
     ) -> Result<Sticker> {
-        http.edit_sticker(guild_id, sticker_id, &self, self.audit_log_reason).await
+        http.edit_sticker(guild_id.0, sticker_id.0, &self, self.audit_log_reason).await
     }
 }

--- a/src/builder/edit_thread.rs
+++ b/src/builder/edit_thread.rs
@@ -109,9 +109,8 @@ impl<'a> EditThread<'a> {
     /// Returns [`ModelError::InvalidChannelType`] if the `ThreadId` is not identifying a thread.
     #[cfg(feature = "http")]
     pub async fn execute(self, http: &Http, thread_id: ThreadId) -> Result<GuildThread> {
-        http.edit_channel(thread_id.widen(), &self, self.audit_log_reason)
-            .await?
-            .thread()
-            .ok_or(Error::Model(ModelError::InvalidChannelType))
+        let channel: Channel =
+            http.edit_channel(thread_id.widen(), &self, self.audit_log_reason).await?;
+        channel.thread().ok_or(Error::Model(ModelError::InvalidChannelType))
     }
 }

--- a/src/builder/edit_thread.rs
+++ b/src/builder/edit_thread.rs
@@ -109,8 +109,7 @@ impl<'a> EditThread<'a> {
     /// Returns [`ModelError::InvalidChannelType`] if the `ThreadId` is not identifying a thread.
     #[cfg(feature = "http")]
     pub async fn execute(self, http: &Http, thread_id: ThreadId) -> Result<GuildThread> {
-        let channel: Channel =
-            http.edit_channel(thread_id.widen(), &self, self.audit_log_reason).await?;
+        let channel: Channel = http.edit_channel(thread_id.0, &self, self.audit_log_reason).await?;
         channel.thread().ok_or(Error::Model(ModelError::InvalidChannelType))
     }
 }

--- a/src/builder/edit_voice_state.rs
+++ b/src/builder/edit_voice_state.rs
@@ -80,9 +80,9 @@ impl EditVoiceState {
     ) -> Result<()> {
         self.channel_id = Some(channel_id);
         if let Some(user_id) = user_id {
-            http.edit_voice_state(guild_id, user_id, &self).await
+            http.edit_voice_state(guild_id.0, user_id.0, &self).await
         } else {
-            http.edit_voice_state_me(guild_id, &self).await
+            http.edit_voice_state_me(guild_id.0, &self).await
         }
     }
 }

--- a/src/builder/edit_webhook.rs
+++ b/src/builder/edit_webhook.rs
@@ -75,9 +75,10 @@ impl<'a> EditWebhook<'a> {
     ) -> Result<Webhook> {
         match webhook_token {
             Some(token) => {
-                http.edit_webhook_with_token(webhook_id, token, &self, self.audit_log_reason).await
+                http.edit_webhook_with_token(webhook_id.0, token, &self, self.audit_log_reason)
+                    .await
             },
-            None => http.edit_webhook(webhook_id, &self, self.audit_log_reason).await,
+            None => http.edit_webhook(webhook_id.0, &self, self.audit_log_reason).await,
         }
     }
 }

--- a/src/builder/edit_webhook_message.rs
+++ b/src/builder/edit_webhook_message.rs
@@ -187,10 +187,10 @@ impl<'a> EditWebhookMessage<'a> {
         }
 
         http.edit_webhook_message(
-            webhook_id,
-            self.thread_id,
+            webhook_id.0,
+            self.thread_id.map(|id| id.0),
             webhook_token,
-            message_id,
+            message_id.0,
             &self,
             files,
         )

--- a/src/builder/entitlements.rs
+++ b/src/builder/entitlements.rs
@@ -124,13 +124,14 @@ impl<'a> GetEntitlements<'a> {
     /// May error due to an invalid response from discord, or network error.
     #[cfg(feature = "http")]
     pub async fn execute(self, http: &Http) -> Result<Vec<Entitlement>> {
+        let sku_ids = self.sku_ids.map(|ids| ids.iter().map(|id| id.0).collect::<Vec<_>>());
         http.get_entitlements(
-            self.user_id,
-            self.sku_ids.as_deref(),
-            self.before,
-            self.after,
+            self.user_id.map(|id| id.0),
+            sku_ids.as_deref(),
+            self.before.map(|id| id.0),
+            self.after.map(|id| id.0),
             self.limit,
-            self.guild_id,
+            self.guild_id.map(|id| id.0),
             self.exclude_ended,
         )
         .await

--- a/src/builder/execute_webhook.rs
+++ b/src/builder/execute_webhook.rs
@@ -365,8 +365,8 @@ impl<'a> ExecuteWebhook<'a> {
 
         if self.with_components.unwrap_or_default() {
             http.execute_webhook_with_components(
-                webhook_id,
-                self.thread_id,
+                webhook_id.0,
+                self.thread_id.map(|id| id.0),
                 webhook_token,
                 wait,
                 files,
@@ -374,8 +374,15 @@ impl<'a> ExecuteWebhook<'a> {
             )
             .await
         } else {
-            http.execute_webhook(webhook_id, self.thread_id, webhook_token, wait, files, &self)
-                .await
+            http.execute_webhook(
+                webhook_id.0,
+                self.thread_id.map(|id| id.0),
+                webhook_token,
+                wait,
+                files,
+                &self,
+            )
+            .await
         }
     }
 }

--- a/src/builder/get_messages.rs
+++ b/src/builder/get_messages.rs
@@ -108,7 +108,7 @@ impl GetMessages {
     ) -> Result<Vec<Message>> {
         let http = cache_http.http();
         let search_filter = self.search_filter.map(Into::into);
-        let messages = http.get_messages(channel_id, search_filter, self.limit).await?;
+        let messages = http.get_messages(channel_id.0, search_filter, self.limit).await?;
 
         #[cfg(feature = "cache")]
         if let Some(cache) = cache_http.cache() {
@@ -131,9 +131,9 @@ enum SearchFilter {
 impl From<SearchFilter> for MessagePagination {
     fn from(filter: SearchFilter) -> Self {
         match filter {
-            SearchFilter::After(id) => MessagePagination::After(id),
-            SearchFilter::Around(id) => MessagePagination::Around(id),
-            SearchFilter::Before(id) => MessagePagination::Before(id),
+            SearchFilter::After(id) => MessagePagination::After(id.0),
+            SearchFilter::Around(id) => MessagePagination::Around(id.0),
+            SearchFilter::Before(id) => MessagePagination::Before(id.0),
         }
     }
 }

--- a/src/gateway/client/context.rs
+++ b/src/gateway/client/context.rs
@@ -327,7 +327,7 @@ impl Context {
     ///
     /// Returns an error if the emoji does not exist.
     pub async fn get_application_emoji(&self, emoji_id: EmojiId) -> Result<Emoji> {
-        self.http.get_application_emoji(emoji_id).await
+        self.http.get_application_emoji(emoji_id.0).await
     }
 
     /// Creates an application emoji with a name and base64-encoded image.
@@ -366,7 +366,7 @@ impl Context {
             name,
         };
 
-        self.http.edit_application_emoji(emoji_id, &body).await
+        self.http.edit_application_emoji(emoji_id.0, &body).await
     }
 
     /// Deletes an application emoji.
@@ -375,6 +375,6 @@ impl Context {
     ///
     /// Returns an error if the emoji does not exist.
     pub async fn delete_application_emoji(&self, emoji_id: EmojiId) -> Result<()> {
-        self.http.delete_application_emoji(emoji_id).await
+        self.http.delete_application_emoji(emoji_id.0).await
     }
 }

--- a/src/gateway/client/mod.rs
+++ b/src/gateway/client/mod.rs
@@ -60,9 +60,11 @@ use crate::framework::Framework;
 use crate::http::Http;
 use crate::internal::prelude::*;
 use crate::internal::tokio::spawn_named;
-use crate::model::gateway::GatewayIntents;
+use crate::model::gateway::{BotGateway, GatewayIntents};
 #[cfg(feature = "voice")]
 use crate::model::id::UserId;
+#[cfg(feature = "voice")]
+use crate::model::user::CurrentUser;
 use crate::model::user::OnlineStatus;
 
 /// A builder implementing [`IntoFuture`] building a [`Client`] to interact with Discord.
@@ -305,17 +307,18 @@ impl IntoFuture for ClientBuilder {
         let cache = Arc::new(Cache::new_with_settings(self.cache_settings));
 
         Box::pin(async move {
-            let (ws_url, shard_total, max_concurrency) = match http.get_bot_gateway().await {
-                Ok(response) => (
-                    Arc::from(response.url),
-                    response.shards,
-                    response.session_start_limit.max_concurrency,
-                ),
-                Err(err) => {
-                    tracing::warn!("HTTP request to get gateway URL failed: {err}");
-                    (Arc::from("wss://gateway.discord.gg"), NonZeroU16::MIN, NonZeroU16::MIN)
-                },
-            };
+            let (ws_url, shard_total, max_concurrency) =
+                match http.get_bot_gateway::<BotGateway>().await {
+                    Ok(response) => (
+                        Arc::from(response.url),
+                        response.shards,
+                        response.session_start_limit.max_concurrency,
+                    ),
+                    Err(err) => {
+                        tracing::warn!("HTTP request to get gateway URL failed: {err}");
+                        (Arc::from("wss://gateway.discord.gg"), NonZeroU16::MIN, NonZeroU16::MIN)
+                    },
+                };
 
             #[cfg(feature = "framework")]
             let framework_cell = Arc::new(OnceLock::new());
@@ -507,7 +510,7 @@ impl Client {
     #[cfg_attr(feature = "tracing_instrument", instrument(skip(self)))]
     pub async fn start_autosharded(&mut self) -> Result<()> {
         let (end, total) = {
-            let res = self.http.get_bot_gateway().await?;
+            let res: BotGateway = self.http.get_bot_gateway().await?;
             (res.shards.get() - 1, res.shards)
         };
 
@@ -681,7 +684,7 @@ impl Client {
 
             let user_id = match cache_user_id {
                 Some(u) => u,
-                None => self.http.get_current_user().await?.id,
+                None => self.http.get_current_user::<CurrentUser>().await?.id,
             };
 
             voice_manager.initialise(total_shards, user_id).await;

--- a/src/gateway/sharding/mod.rs
+++ b/src/gateway/sharding/mod.rs
@@ -118,7 +118,7 @@ impl Shard {
     /// use std::sync::Arc;
     ///
     /// use serenity::gateway::{Shard, TransportCompression};
-    /// use serenity::model::gateway::{GatewayIntents, ShardInfo};
+    /// use serenity::model::gateway::{Gateway, GatewayIntents, ShardInfo};
     /// use serenity::model::id::ShardId;
     /// use serenity::secrets::Token;
     /// use tokio::sync::Mutex;
@@ -134,7 +134,7 @@ impl Shard {
     /// };
     ///
     /// // retrieve the gateway response, which contains the URL to connect to
-    /// let gateway = Arc::from(http.get_gateway().await?.url);
+    /// let gateway = Arc::from(http.get_gateway::<Gateway>().await?.url);
     /// let shard = Shard::new(
     ///     gateway,
     ///     token,

--- a/src/gateway/sharding/shard_manager.rs
+++ b/src/gateway/sharding/shard_manager.rs
@@ -244,7 +244,7 @@ impl ShardManager {
         .await?;
 
         let cloned_http = Arc::clone(&self.http);
-        shard.set_application_id_callback(move |id| cloned_http.set_application_id(id));
+        shard.set_application_id_callback(move |id| cloned_http.set_application_id(id.0));
 
         let (runner_tx, runner_rx) = mpsc::unbounded();
         let runner_info = Arc::new(RwLock::new(ShardRunnerInfo {

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -13,7 +13,7 @@ use reqwest::Url;
 use reqwest::header::{HeaderMap as Headers, HeaderValue};
 use reqwest::{Client, ClientBuilder, Response as ReqwestResponse, StatusCode};
 use serde::de::DeserializeOwned;
-use serde::ser::SerializeSeq as _;
+use serde::ser::{Serialize, SerializeSeq as _, Serializer};
 use serde_json::{from_value, to_string, to_vec};
 use to_arraystring::ToArrayString as _;
 #[cfg(feature = "tracing_instrument")]
@@ -45,12 +45,12 @@ impl<I> SerializeIter<I> {
     }
 }
 
-impl<Iter, Item> serde::Serialize for SerializeIter<Iter>
+impl<Iter, Item> Serialize for SerializeIter<Iter>
 where
     Iter: Iterator<Item = Item>,
-    Item: serde::Serialize,
+    Item: Serialize,
 {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let Some(iter) = self.0.take() else {
             return serializer.serialize_seq(Some(0))?.end();
         };
@@ -277,12 +277,12 @@ impl Http {
     /// Adds a [`User`] to a [`Guild`] with a valid OAuth2 access token.
     ///
     /// Returns the created [`Member`] object, or nothing if the user is already a guild member.
-    pub async fn add_guild_member(
+    pub async fn add_guild_member<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         user_id: UserId,
-        map: &impl serde::Serialize,
-    ) -> Result<Option<Member>> {
+        map: &impl Serialize,
+    ) -> Result<Option<T>> {
         let response = self
             .request(Request {
                 body: Some(to_vec(map)?),
@@ -353,12 +353,12 @@ impl Http {
     ///
     /// See the [Discord docs](https://docs.discord.com/developers/resources/guild#bulk-guild-ban)
     /// for more information.
-    pub async fn bulk_ban_users(
+    pub async fn bulk_ban_users<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         reason: Option<&str>,
-    ) -> Result<BulkBanResponse> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -388,12 +388,12 @@ impl Http {
     }
 
     /// Creates a [`GuildChannel`] in the [`Guild`] given its Id.
-    pub async fn create_channel(
+    pub async fn create_channel<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<GuildChannel> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -408,11 +408,11 @@ impl Http {
     }
 
     /// Creates a stage instance.
-    pub async fn create_stage_instance(
+    pub async fn create_stage_instance<T: DeserializeOwned>(
         &self,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<StageInstance> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -425,13 +425,13 @@ impl Http {
     }
 
     /// Creates a thread channel in the [`GuildChannel`] given its Id, with a base message Id.
-    pub async fn create_thread_from_message(
+    pub async fn create_thread_from_message<T: DeserializeOwned>(
         &self,
         channel_id: ChannelId,
         message_id: MessageId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<GuildThread> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -447,12 +447,12 @@ impl Http {
     }
 
     /// Creates a thread channel not attached to a message in the [`GuildChannel`] given its Id.
-    pub async fn create_thread(
+    pub async fn create_thread<T: DeserializeOwned>(
         &self,
         channel_id: ChannelId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<GuildThread> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -467,13 +467,13 @@ impl Http {
     }
 
     /// Creates a forum post channel in the [`GuildChannel`] given its Id.
-    pub async fn create_forum_post(
+    pub async fn create_forum_post<T: DeserializeOwned>(
         &self,
         channel_id: ChannelId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         files: Vec<AttachmentData<'_>>,
         audit_log_reason: Option<&str>,
-    ) -> Result<GuildThread> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: Some(Multipart {
@@ -492,12 +492,12 @@ impl Http {
     }
 
     /// Creates an emoji in the given [`Guild`] with the given data.
-    pub async fn create_emoji(
+    pub async fn create_emoji<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<Emoji> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -516,7 +516,10 @@ impl Http {
     /// See [`Context::create_application_emoji`] for required fields.
     ///
     /// [`Context::create_application_emoji`]: crate::gateway::client::Context::create_application_emoji
-    pub async fn create_application_emoji(&self, map: &impl serde::Serialize) -> Result<Emoji> {
+    pub async fn create_application_emoji<T: DeserializeOwned>(
+        &self,
+        map: &impl Serialize,
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -533,12 +536,12 @@ impl Http {
     /// Create a follow-up message for an Interaction.
     ///
     /// Functions the same as [`Self::execute_webhook`]
-    pub async fn create_followup_message(
+    pub async fn create_followup_message<T: DeserializeOwned>(
         &self,
         interaction_token: &str,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         files: Vec<AttachmentData<'_>>,
-    ) -> Result<Message> {
+    ) -> Result<T> {
         let mut request = Request {
             body: None,
             multipart: None,
@@ -565,7 +568,10 @@ impl Http {
     }
 
     /// Creates a new global command.
-    pub async fn create_global_command(&self, map: &impl serde::Serialize) -> Result<Command> {
+    pub async fn create_global_command<T: DeserializeOwned>(
+        &self,
+        map: &impl Serialize,
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -580,10 +586,10 @@ impl Http {
     }
 
     /// Creates new global application commands.
-    pub async fn create_global_commands(
+    pub async fn create_global_commands<T: DeserializeOwned>(
         &self,
-        map: &impl serde::Serialize,
-    ) -> Result<Vec<Command>> {
+        map: &impl Serialize,
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -598,11 +604,11 @@ impl Http {
     }
 
     /// Creates new guild application commands.
-    pub async fn create_guild_commands(
+    pub async fn create_guild_commands<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
-    ) -> Result<Vec<Command>> {
+        map: &impl Serialize,
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -624,7 +630,7 @@ impl Http {
     ///
     /// [`Shard`]: crate::gateway::Shard
     #[deprecated = "This endpoint has been deprecated by Discord and will stop functioning after July 15, 2025. For more information, see: https://docs.discord.com/developers/change-log#deprecating-guild-creation-by-apps"]
-    pub async fn create_guild(&self, map: &impl serde::Serialize) -> Result<PartialGuild> {
+    pub async fn create_guild<T: DeserializeOwned>(&self, map: &impl Serialize) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -639,11 +645,11 @@ impl Http {
     /// Creates a new guild command.
     ///
     /// New guild commands will be available in the guild immediately.
-    pub async fn create_guild_command(
+    pub async fn create_guild_command<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
-    ) -> Result<Command> {
+        map: &impl Serialize,
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -663,7 +669,7 @@ impl Http {
         &self,
         guild_id: GuildId,
         integration_id: IntegrationId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
         self.wind(Request {
@@ -685,7 +691,7 @@ impl Http {
         &self,
         interaction_id: InteractionId,
         interaction_token: &str,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         files: Vec<AttachmentData<'_>>,
     ) -> Result<()> {
         let mut request = Request {
@@ -714,12 +720,12 @@ impl Http {
     }
 
     /// Creates an [`Invite`] for the given [channel][`GuildChannel`].
-    pub async fn create_invite(
+    pub async fn create_invite<T: DeserializeOwned>(
         &self,
         channel_id: ChannelId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<Invite> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -738,7 +744,7 @@ impl Http {
         &self,
         channel_id: ChannelId,
         target_id: TargetId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
         self.wind(Request {
@@ -756,10 +762,10 @@ impl Http {
     }
 
     /// Creates a private channel with a user.
-    pub async fn create_private_channel(
+    pub async fn create_private_channel<T: DeserializeOwned>(
         &self,
-        map: &impl serde::Serialize,
-    ) -> Result<PrivateChannel> {
+        map: &impl Serialize,
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -794,12 +800,12 @@ impl Http {
     }
 
     /// Creates a role.
-    pub async fn create_role(
+    pub async fn create_role<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<Role> {
+    ) -> Result<T> {
         let mut value: Value = self
             .fire(Request {
                 body: Some(to_vec(map)?),
@@ -821,12 +827,12 @@ impl Http {
     }
 
     /// Creates a Guild Scheduled Event.
-    pub async fn create_scheduled_event(
+    pub async fn create_scheduled_event<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<ScheduledEvent> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -841,13 +847,13 @@ impl Http {
     }
 
     /// Creates a sticker.
-    pub async fn create_sticker(
+    pub async fn create_sticker<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         fields: Vec<(Cow<'static, str>, Cow<'static, str>)>,
         file: AttachmentData<'_>,
         audit_log_reason: Option<&str>,
-    ) -> Result<Sticker> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: Some(Multipart {
@@ -868,10 +874,10 @@ impl Http {
     /// Creates a test entitlement to a given SKU for a given guild or user. Discord will act as
     /// though that user/guild has entitlement in perpetuity to the SKU. As a result, the returned
     /// entitlement will have `starts_at` and `ends_at` both be `None`.
-    pub async fn create_test_entitlement(
+    pub async fn create_test_entitlement<T: DeserializeOwned>(
         &self,
-        map: &impl serde::Serialize,
-    ) -> Result<Entitlement> {
+        map: &impl Serialize,
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(&map)?),
             multipart: None,
@@ -886,12 +892,12 @@ impl Http {
     }
 
     /// Creates a webhook for the given [`GuildChannel`]'s Id, passing in the given data.
-    pub async fn create_webhook(
+    pub async fn create_webhook<T: DeserializeOwned>(
         &self,
         channel_id: ChannelId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<Webhook> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -906,11 +912,11 @@ impl Http {
     }
 
     /// Deletes a private channel or a channel in a guild.
-    pub async fn delete_channel(
+    pub async fn delete_channel<T: DeserializeOwned>(
         &self,
         channel_id: GenericChannelId,
         audit_log_reason: Option<&str>,
-    ) -> Result<Channel> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -1075,11 +1081,11 @@ impl Http {
     }
 
     /// Deletes an invite by code.
-    pub async fn delete_invite(
+    pub async fn delete_invite<T: DeserializeOwned>(
         &self,
         code: &str,
         audit_log_reason: Option<&str>,
-    ) -> Result<Invite> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -1118,7 +1124,7 @@ impl Http {
     pub async fn delete_messages(
         &self,
         channel_id: GenericChannelId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
         self.wind(Request {
@@ -1384,12 +1390,12 @@ impl Http {
     }
 
     /// Changes channel information.
-    pub async fn edit_channel(
+    pub async fn edit_channel<T: DeserializeOwned>(
         &self,
         channel_id: GenericChannelId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<Channel> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -1404,12 +1410,12 @@ impl Http {
     }
 
     /// Edits a stage instance.
-    pub async fn edit_stage_instance(
+    pub async fn edit_stage_instance<T: DeserializeOwned>(
         &self,
         channel_id: ChannelId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<StageInstance> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -1424,13 +1430,13 @@ impl Http {
     }
 
     /// Changes guild emoji information.
-    pub async fn edit_emoji(
+    pub async fn edit_emoji<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         emoji_id: EmojiId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<Emoji> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -1450,11 +1456,11 @@ impl Http {
     /// See [`Context::edit_application_emoji`] for required fields.
     ///
     /// [`Context::edit_application_emoji`]: crate::gateway::client::Context::edit_application_emoji
-    pub async fn edit_application_emoji(
+    pub async fn edit_application_emoji<T: DeserializeOwned>(
         &self,
         emoji_id: EmojiId,
-        map: &impl serde::Serialize,
-    ) -> Result<Emoji> {
+        map: &impl Serialize,
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -1470,13 +1476,13 @@ impl Http {
     }
 
     /// Edits a follow-up message for an interaction.
-    pub async fn edit_followup_message(
+    pub async fn edit_followup_message<T: DeserializeOwned>(
         &self,
         interaction_token: &str,
         message_id: MessageId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         new_attachments: Vec<AttachmentData<'_>>,
-    ) -> Result<Message> {
+    ) -> Result<T> {
         let mut request = Request {
             body: None,
             multipart: None,
@@ -1504,11 +1510,11 @@ impl Http {
     }
 
     /// Get a follow-up message for an interaction.
-    pub async fn get_followup_message(
+    pub async fn get_followup_message<T: DeserializeOwned>(
         &self,
         interaction_token: &str,
         message_id: MessageId,
-    ) -> Result<Message> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -1525,11 +1531,11 @@ impl Http {
     }
 
     /// Edits a global command.
-    pub async fn edit_global_command(
+    pub async fn edit_global_command<T: DeserializeOwned>(
         &self,
         command_id: CommandId,
-        map: &impl serde::Serialize,
-    ) -> Result<Command> {
+        map: &impl Serialize,
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -1545,12 +1551,12 @@ impl Http {
     }
 
     /// Changes guild information.
-    pub async fn edit_guild(
+    pub async fn edit_guild<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<PartialGuild> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -1565,12 +1571,12 @@ impl Http {
     }
 
     /// Edits a guild command.
-    pub async fn edit_guild_command(
+    pub async fn edit_guild_command<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         command_id: CommandId,
-        map: &impl serde::Serialize,
-    ) -> Result<Command> {
+        map: &impl Serialize,
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -1587,12 +1593,12 @@ impl Http {
     }
 
     /// Edits a guild command permissions.
-    pub async fn edit_guild_command_permissions(
+    pub async fn edit_guild_command_permissions<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         command_id: CommandId,
-        map: &impl serde::Serialize,
-    ) -> Result<CommandPermissions> {
+        map: &impl Serialize,
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -1612,7 +1618,7 @@ impl Http {
     pub async fn edit_guild_channel_positions(
         &self,
         guild_id: GuildId,
-        value: impl Iterator<Item: serde::Serialize>,
+        value: impl Iterator<Item: Serialize>,
     ) -> Result<()> {
         let body = to_vec(&SerializeIter::new(value))?;
 
@@ -1630,38 +1636,38 @@ impl Http {
     }
 
     /// Edits the MFA level of a guild. Requires guild ownership.
-    pub async fn edit_guild_mfa_level(
+    pub async fn edit_guild_mfa_level<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<MfaLevel> {
-        #[derive(Deserialize)]
-        struct GuildMfaLevel {
-            level: MfaLevel,
-        }
+    ) -> Result<T> {
+        let resp = self
+            .fire::<Value>(Request {
+                body: Some(to_vec(map)?),
+                multipart: None,
+                headers: audit_log_reason.map(reason_into_header),
+                method: LightMethod::Post,
+                route: Route::GuildMfa {
+                    guild_id,
+                },
+                params: None,
+            })
+            .await?
+            .get_mut("level")
+            .map(Value::take)
+            .unwrap_or_default();
 
-        self.fire(Request {
-            body: Some(to_vec(map)?),
-            multipart: None,
-            headers: audit_log_reason.map(reason_into_header),
-            method: LightMethod::Post,
-            route: Route::GuildMfa {
-                guild_id,
-            },
-            params: None,
-        })
-        .await
-        .map(|mfa: GuildMfaLevel| mfa.level)
+        from_value(resp).map_err(From::from)
     }
 
     /// Edits a [`Guild`]'s widget.
-    pub async fn edit_guild_widget(
+    pub async fn edit_guild_widget<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<GuildWidget> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -1676,12 +1682,12 @@ impl Http {
     }
 
     /// Edits a guild welcome screen.
-    pub async fn edit_guild_welcome_screen(
+    pub async fn edit_guild_welcome_screen<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<GuildWelcomeScreen> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -1696,13 +1702,13 @@ impl Http {
     }
 
     /// Does specific actions to a member.
-    pub async fn edit_member(
+    pub async fn edit_member<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         user_id: UserId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<Member> {
+    ) -> Result<T> {
         let mut value: Value = self
             .fire(Request {
                 body: Some(to_vec(map)?),
@@ -1721,19 +1727,19 @@ impl Http {
             map.insert("guild_id".to_string(), guild_id.get().into());
         }
 
-        from_value::<Member>(value).map_err(From::from)
+        from_value(value).map_err(From::from)
     }
 
     /// Edits a message by Id.
     ///
     /// **Note**: Only the author of a message can modify it.
-    pub async fn edit_message(
+    pub async fn edit_message<T: DeserializeOwned>(
         &self,
         channel_id: GenericChannelId,
         message_id: MessageId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         new_attachments: Vec<AttachmentData<'_>>,
-    ) -> Result<Message> {
+    ) -> Result<T> {
         let mut request = Request {
             body: None,
             multipart: None,
@@ -1762,11 +1768,11 @@ impl Http {
     /// Crossposts a message by Id.
     ///
     /// **Note**: Only available on news channels.
-    pub async fn crosspost_message(
+    pub async fn crosspost_message<T: DeserializeOwned>(
         &self,
         channel_id: ChannelId,
         message_id: MessageId,
-    ) -> Result<Message> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -1782,12 +1788,12 @@ impl Http {
     }
 
     /// Edits the current member for the provided [`Guild`] via its Id.
-    pub async fn edit_current_member(
+    pub async fn edit_current_member<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<Member> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(&map)?),
             multipart: None,
@@ -1802,11 +1808,11 @@ impl Http {
     }
 
     /// Follow a News Channel to send messages to a target channel.
-    pub async fn follow_news_channel(
+    pub async fn follow_news_channel<T: DeserializeOwned>(
         &self,
         news_channel_id: ChannelId,
-        map: &impl serde::Serialize,
-    ) -> Result<FollowedChannel> {
+        map: &impl Serialize,
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(&map)?),
             multipart: None,
@@ -1821,10 +1827,10 @@ impl Http {
     }
 
     /// Gets the initial interaction response.
-    pub async fn get_original_interaction_response(
+    pub async fn get_original_interaction_response<T: DeserializeOwned>(
         &self,
         interaction_token: &str,
-    ) -> Result<Message> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -1840,12 +1846,12 @@ impl Http {
     }
 
     /// Edits the initial interaction response.
-    pub async fn edit_original_interaction_response(
+    pub async fn edit_original_interaction_response<T: DeserializeOwned>(
         &self,
         interaction_token: &str,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         new_attachments: Vec<AttachmentData<'_>>,
-    ) -> Result<Message> {
+    ) -> Result<T> {
         let mut request = Request {
             body: None,
             multipart: None,
@@ -1872,7 +1878,7 @@ impl Http {
     }
 
     /// Edits the current user's profile settings.
-    pub async fn edit_profile(&self, map: &impl serde::Serialize) -> Result<CurrentUser> {
+    pub async fn edit_profile<T: DeserializeOwned>(&self, map: &impl Serialize) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -1885,13 +1891,13 @@ impl Http {
     }
 
     /// Changes a role in a guild.
-    pub async fn edit_role(
+    pub async fn edit_role<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         role_id: RoleId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<Role> {
+    ) -> Result<T> {
         let mut value: Value = self
             .fire(Request {
                 body: Some(to_vec(map)?),
@@ -1914,12 +1920,12 @@ impl Http {
     }
 
     /// Changes the positions of roles in a guild.
-    pub async fn edit_role_positions(
+    pub async fn edit_role_positions<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        positions: impl Iterator<Item: serde::Serialize>,
+        positions: impl Iterator<Item: Serialize>,
         audit_log_reason: Option<&str>,
-    ) -> Result<Vec<Role>> {
+    ) -> Result<Vec<T>> {
         let body = to_vec(&SerializeIter::new(positions))?;
 
         let mut value: Value = self
@@ -1951,13 +1957,13 @@ impl Http {
     /// **Note**: Requires the [Manage Events] permission.
     ///
     /// [Manage Events]: Permissions::MANAGE_EVENTS
-    pub async fn edit_scheduled_event(
+    pub async fn edit_scheduled_event<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         event_id: ScheduledEventId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<ScheduledEvent> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -1975,13 +1981,13 @@ impl Http {
     /// Changes a sticker in a guild.
     ///
     /// See [`GuildId::edit_sticker`] for permissions requirements.
-    pub async fn edit_sticker(
+    pub async fn edit_sticker<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         sticker_id: StickerId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<Sticker> {
+    ) -> Result<T> {
         let mut value: Value = self
             .fire(Request {
                 body: Some(to_vec(map)?),
@@ -2008,7 +2014,7 @@ impl Http {
         &self,
         guild_id: GuildId,
         user_id: UserId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
     ) -> Result<()> {
         self.wind(Request {
             body: Some(to_vec(map)?),
@@ -2025,11 +2031,7 @@ impl Http {
     }
 
     /// Changes the current user's voice state in a stage channel.
-    pub async fn edit_voice_state_me(
-        &self,
-        guild_id: GuildId,
-        map: &impl serde::Serialize,
-    ) -> Result<()> {
+    pub async fn edit_voice_state_me(&self, guild_id: GuildId, map: &impl Serialize) -> Result<()> {
         self.wind(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -2047,7 +2049,7 @@ impl Http {
     pub async fn edit_voice_status(
         &self,
         channel_id: ChannelId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
         self.wind(Request {
@@ -2064,12 +2066,12 @@ impl Http {
     }
 
     /// Edits a the webhook with the given data.
-    pub async fn edit_webhook(
+    pub async fn edit_webhook<T: DeserializeOwned>(
         &self,
         webhook_id: WebhookId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<Webhook> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -2084,13 +2086,13 @@ impl Http {
     }
 
     /// Edits the webhook with the given data.
-    pub async fn edit_webhook_with_token(
+    pub async fn edit_webhook_with_token<T: DeserializeOwned>(
         &self,
         webhook_id: WebhookId,
         token: &str,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<Webhook> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -2106,15 +2108,15 @@ impl Http {
     }
 
     /// Executes a webhook, posting a [`Message`] in the webhook's associated [`Channel`].
-    pub async fn execute_webhook(
+    pub async fn execute_webhook<T: DeserializeOwned>(
         &self,
         webhook_id: WebhookId,
         thread_id: Option<ThreadId>,
         token: &str,
         wait: bool,
         files: Vec<AttachmentData<'_>>,
-        map: &impl serde::Serialize,
-    ) -> Result<Option<Message>> {
+        map: &impl Serialize,
+    ) -> Result<Option<T>> {
         self.execute_webhook_(webhook_id, thread_id, token, wait, files, map, false).await
     }
 
@@ -2124,29 +2126,29 @@ impl Http {
     /// Refer to the [Discord docs] for more information on how this works.
     ///
     /// [Discord docs]: https://docs.discord.com/developers/resources/webhook#execute-webhook-query-string-params
-    pub async fn execute_webhook_with_components(
+    pub async fn execute_webhook_with_components<T: DeserializeOwned>(
         &self,
         webhook_id: WebhookId,
         thread_id: Option<ThreadId>,
         token: &str,
         wait: bool,
         files: Vec<AttachmentData<'_>>,
-        map: &impl serde::Serialize,
-    ) -> Result<Option<Message>> {
+        map: &impl Serialize,
+    ) -> Result<Option<T>> {
         self.execute_webhook_(webhook_id, thread_id, token, wait, files, map, true).await
     }
 
     #[expect(clippy::too_many_arguments)]
-    async fn execute_webhook_(
+    async fn execute_webhook_<T: DeserializeOwned>(
         &self,
         webhook_id: WebhookId,
         thread_id: Option<ThreadId>,
         token: &str,
         wait: bool,
         files: Vec<AttachmentData<'_>>,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         with_components: bool,
-    ) -> Result<Option<Message>> {
+    ) -> Result<Option<T>> {
         let (thread_id_str, with_components_str);
         let wait_str = wait.to_arraystring();
         let mut params = ArrayVec::<_, 3>::new();
@@ -2190,13 +2192,13 @@ impl Http {
     }
 
     // Gets a webhook's message by Id
-    pub async fn get_webhook_message(
+    pub async fn get_webhook_message<T: DeserializeOwned>(
         &self,
         webhook_id: WebhookId,
         thread_id: Option<ThreadId>,
         token: &str,
         message_id: MessageId,
-    ) -> Result<Message> {
+    ) -> Result<T> {
         let thread_id_str;
         let mut params = None;
 
@@ -2221,15 +2223,15 @@ impl Http {
     }
 
     /// Edits a webhook's message by Id.
-    pub async fn edit_webhook_message(
+    pub async fn edit_webhook_message<T: DeserializeOwned>(
         &self,
         webhook_id: WebhookId,
         thread_id: Option<ThreadId>,
         token: &str,
         message_id: MessageId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         new_attachments: Vec<AttachmentData<'_>>,
-    ) -> Result<Message> {
+    ) -> Result<T> {
         let thread_id_str;
         let mut params = None;
 
@@ -2298,15 +2300,9 @@ impl Http {
     /// Gets the active maintenances from Discord's Status API.
     ///
     /// Does not require authentication.
-    pub async fn get_active_maintenances(&self) -> Result<Vec<Maintenance>> {
-        #[derive(Deserialize)]
-        struct StatusResponse {
-            #[serde(default)]
-            scheduled_maintenances: Vec<Maintenance>,
-        }
-
-        let status: StatusResponse = self
-            .fire(Request {
+    pub async fn get_active_maintenances<T: DeserializeOwned>(&self) -> Result<Vec<T>> {
+        let status = self
+            .fire::<Value>(Request {
                 body: None,
                 multipart: None,
                 headers: None,
@@ -2314,9 +2310,14 @@ impl Http {
                 route: Route::StatusMaintenancesActive,
                 params: None,
             })
-            .await?;
+            .await?
+            .get_mut("scheduled_maintenances")
+            .map(Value::take);
 
-        Ok(status.scheduled_maintenances)
+        match status {
+            Some(status) => from_value(status).map_err(From::from),
+            None => Ok(vec![]),
+        }
     }
 
     /// Gets all the users that are banned in specific guild, with additional options for
@@ -2329,12 +2330,12 @@ impl Http {
     /// after the provided [`UserId`] wrapped by the [`UserPagination`].
     ///
     /// [`UserId`]: crate::model::id::UserId
-    pub async fn get_bans(
+    pub async fn get_bans<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         target: Option<UserPagination>,
         limit: Option<NonMaxU16>,
-    ) -> Result<Vec<Ban>> {
+    ) -> Result<Vec<T>> {
         let id_str;
         let limit_str;
         let mut params = ArrayVec::<_, 2>::new();
@@ -2377,7 +2378,11 @@ impl Http {
     /// Returns [`Error::Http`] if the current user lacks permission.
     ///
     /// [Ban Members]: Permissions::BAN_MEMBERS
-    pub async fn get_ban(&self, guild_id: GuildId, user_id: UserId) -> Result<Option<Ban>> {
+    pub async fn get_ban<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+        user_id: UserId,
+    ) -> Result<Option<T>> {
         let result = self
             .fire(Request {
                 body: None,
@@ -2402,7 +2407,7 @@ impl Http {
     }
 
     /// Gets all audit logs in a specific guild.
-    pub async fn get_audit_logs(
+    pub async fn get_audit_logs<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         action_type: Option<u16>,
@@ -2410,7 +2415,7 @@ impl Http {
         before: Option<AuditLogEntryId>,
         after: Option<AuditLogEntryId>,
         limit: Option<NonMaxU8>,
-    ) -> Result<AuditLogs> {
+    ) -> Result<T> {
         let (action_type_str, before_str, after_str, limit_str, user_id_str);
         let mut params = ArrayVec::<_, 4>::new();
         if let Some(action_type) = action_type {
@@ -2448,7 +2453,10 @@ impl Http {
     }
 
     /// Retrieves all auto moderation rules in a guild.
-    pub async fn get_automod_rules(&self, guild_id: GuildId) -> Result<Vec<AutoModRule>> {
+    pub async fn get_automod_rules<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+    ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2463,11 +2471,11 @@ impl Http {
     }
 
     /// Retrieves an auto moderation rule in a guild.
-    pub async fn get_automod_rule(
+    pub async fn get_automod_rule<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         rule_id: RuleId,
-    ) -> Result<AutoModRule> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2483,12 +2491,12 @@ impl Http {
     }
 
     /// Creates an auto moderation rule in a guild.
-    pub async fn create_automod_rule(
+    pub async fn create_automod_rule<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<AutoModRule> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -2503,13 +2511,13 @@ impl Http {
     }
 
     /// Retrieves an auto moderation rule in a guild.
-    pub async fn edit_automod_rule(
+    pub async fn edit_automod_rule<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         rule_id: RuleId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<AutoModRule> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -2546,7 +2554,7 @@ impl Http {
     }
 
     /// Gets current bot gateway.
-    pub async fn get_bot_gateway(&self) -> Result<BotGateway> {
+    pub async fn get_bot_gateway<T: DeserializeOwned>(&self) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2559,7 +2567,10 @@ impl Http {
     }
 
     /// Gets all invites for a channel.
-    pub async fn get_channel_invites(&self, channel_id: ChannelId) -> Result<Vec<Invite>> {
+    pub async fn get_channel_invites<T: DeserializeOwned>(
+        &self,
+        channel_id: ChannelId,
+    ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2574,10 +2585,10 @@ impl Http {
     }
 
     /// Gets all thread members for a thread.
-    pub async fn get_channel_thread_members(
+    pub async fn get_channel_thread_members<T: DeserializeOwned>(
         &self,
         thread_id: ThreadId,
-    ) -> Result<Vec<ThreadMember>> {
+    ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2592,7 +2603,10 @@ impl Http {
     }
 
     /// Gets all active threads from a guild.
-    pub async fn get_guild_active_threads(&self, guild_id: GuildId) -> Result<ThreadsData> {
+    pub async fn get_guild_active_threads<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2607,12 +2621,12 @@ impl Http {
     }
 
     /// Gets all archived public threads from a channel.
-    pub async fn get_channel_archived_public_threads(
+    pub async fn get_channel_archived_public_threads<T: DeserializeOwned>(
         &self,
         channel_id: ChannelId,
         before: Option<Timestamp>,
         limit: Option<u64>,
-    ) -> Result<ThreadsData> {
+    ) -> Result<T> {
         let (before_str, limit_str);
         let mut params = ArrayVec::<_, 2>::new();
         if let Some(before) = before {
@@ -2638,12 +2652,12 @@ impl Http {
     }
 
     /// Gets all archived private threads from a channel.
-    pub async fn get_channel_archived_private_threads(
+    pub async fn get_channel_archived_private_threads<T: DeserializeOwned>(
         &self,
         channel_id: ChannelId,
         before: Option<Timestamp>,
         limit: Option<u64>,
-    ) -> Result<ThreadsData> {
+    ) -> Result<T> {
         let (before_str, limit_str);
         let mut params = ArrayVec::<_, 2>::new();
         if let Some(before) = before {
@@ -2669,12 +2683,12 @@ impl Http {
     }
 
     /// Gets all archived private threads joined from a channel.
-    pub async fn get_channel_joined_archived_private_threads(
+    pub async fn get_channel_joined_archived_private_threads<T: DeserializeOwned>(
         &self,
         channel_id: ChannelId,
         before: Option<ChannelId>,
         limit: Option<u64>,
-    ) -> Result<ThreadsData> {
+    ) -> Result<T> {
         let (before_str, limit_str);
         let mut params = ArrayVec::<_, 2>::new();
         if let Some(before) = before {
@@ -2769,12 +2783,12 @@ impl Http {
         .await
     }
 
-    pub async fn get_thread_channel_member(
+    pub async fn get_thread_channel_member<T: DeserializeOwned>(
         &self,
         thread_id: ThreadId,
         user_id: UserId,
         with_member: bool,
-    ) -> Result<ThreadMember> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2790,7 +2804,10 @@ impl Http {
     }
 
     /// Retrieves the webhooks for the given [channel][`GuildChannel`]'s Id.
-    pub async fn get_channel_webhooks(&self, channel_id: ChannelId) -> Result<Vec<Webhook>> {
+    pub async fn get_channel_webhooks<T: DeserializeOwned>(
+        &self,
+        channel_id: ChannelId,
+    ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2805,7 +2822,10 @@ impl Http {
     }
 
     /// Gets channel information.
-    pub async fn get_channel(&self, channel_id: GenericChannelId) -> Result<Channel> {
+    pub async fn get_channel<T: DeserializeOwned>(
+        &self,
+        channel_id: GenericChannelId,
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2820,10 +2840,10 @@ impl Http {
     }
 
     /// Gets all channels in a guild.
-    pub async fn get_channels(
+    pub async fn get_channels<T: DeserializeOwned + ExtractKey<ChannelId>>(
         &self,
         guild_id: GuildId,
-    ) -> Result<ExtractMap<ChannelId, GuildChannel>> {
+    ) -> Result<ExtractMap<ChannelId, T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2838,7 +2858,10 @@ impl Http {
     }
 
     /// Gets a stage instance.
-    pub async fn get_stage_instance(&self, channel_id: ChannelId) -> Result<StageInstance> {
+    pub async fn get_stage_instance<T: DeserializeOwned>(
+        &self,
+        channel_id: ChannelId,
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2853,19 +2876,14 @@ impl Http {
     }
 
     /// Get a list of users that voted for this specific answer.
-    pub async fn get_poll_answer_voters(
+    pub async fn get_poll_answer_voters<T: DeserializeOwned>(
         &self,
         channel_id: GenericChannelId,
         message_id: MessageId,
         answer_id: AnswerId,
         after: Option<UserId>,
         limit: Option<u8>,
-    ) -> Result<Vec<User>> {
-        #[derive(Deserialize)]
-        struct VotersResponse {
-            users: Vec<User>,
-        }
-
+    ) -> Result<Vec<T>> {
         let (after_str, limit_str);
         let mut params = ArrayVec::<_, 2>::new();
         if let Some(after) = after {
@@ -2878,8 +2896,8 @@ impl Http {
             params.push(("limit", &limit_str));
         }
 
-        let resp: VotersResponse = self
-            .fire(Request {
+        let resp = self
+            .fire::<Value>(Request {
                 body: None,
                 multipart: None,
                 headers: None,
@@ -2891,16 +2909,19 @@ impl Http {
                 },
                 params: Some(&params),
             })
-            .await?;
+            .await?
+            .get_mut("users")
+            .map(Value::take)
+            .unwrap_or_default();
 
-        Ok(resp.users)
+        from_value(resp).map_err(From::from)
     }
 
-    pub async fn expire_poll(
+    pub async fn expire_poll<T: DeserializeOwned>(
         &self,
         channel_id: GenericChannelId,
         message_id: MessageId,
-    ) -> Result<Message> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2918,7 +2939,7 @@ impl Http {
     /// Gets information about the current application.
     ///
     /// **Note**: Only applications may use this endpoint.
-    pub async fn get_current_application_info(&self) -> Result<CurrentApplicationInfo> {
+    pub async fn get_current_application_info<T: DeserializeOwned>(&self) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2931,7 +2952,7 @@ impl Http {
     }
 
     /// Gets information about the user we're connected with.
-    pub async fn get_current_user(&self) -> Result<CurrentUser> {
+    pub async fn get_current_user<T: DeserializeOwned>(&self) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2944,7 +2965,7 @@ impl Http {
     }
 
     /// Gets all emojis of a guild.
-    pub async fn get_emojis(&self, guild_id: GuildId) -> Result<Vec<Emoji>> {
+    pub async fn get_emojis<T: DeserializeOwned>(&self, guild_id: GuildId) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2959,7 +2980,11 @@ impl Http {
     }
 
     /// Gets information about an emoji in a guild.
-    pub async fn get_emoji(&self, guild_id: GuildId, emoji_id: EmojiId) -> Result<Emoji> {
+    pub async fn get_emoji<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+        emoji_id: EmojiId,
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2975,15 +3000,9 @@ impl Http {
     }
 
     /// Gets all emojis for the current application.
-    pub async fn get_application_emojis(&self) -> Result<Vec<Emoji>> {
-        // Why, discord...
-        #[derive(Deserialize)]
-        struct ApplicationEmojis {
-            items: Vec<Emoji>,
-        }
-
-        let result: ApplicationEmojis = self
-            .fire(Request {
+    pub async fn get_application_emojis<T: DeserializeOwned>(&self) -> Result<Vec<T>> {
+        let result = self
+            .fire::<Value>(Request {
                 body: None,
                 multipart: None,
                 headers: None,
@@ -2993,13 +3012,16 @@ impl Http {
                 },
                 params: None,
             })
-            .await?;
+            .await?
+            .get_mut("items")
+            .map(Value::take)
+            .unwrap_or_default();
 
-        Ok(result.items)
+        from_value(result).map_err(From::from)
     }
 
     /// Gets information about an application emoji.
-    pub async fn get_application_emoji(&self, emoji_id: EmojiId) -> Result<Emoji> {
+    pub async fn get_application_emoji<T: DeserializeOwned>(&self, emoji_id: EmojiId) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3038,7 +3060,7 @@ impl Http {
 
     #[expect(clippy::too_many_arguments)]
     /// Gets all entitlements for the current app, active and expired.
-    pub async fn get_entitlements(
+    pub async fn get_entitlements<T: DeserializeOwned>(
         &self,
         user_id: Option<UserId>,
         sku_ids: Option<&[SkuId]>,
@@ -3047,7 +3069,7 @@ impl Http {
         limit: Option<NonMaxU8>,
         guild_id: Option<GuildId>,
         exclude_ended: Option<bool>,
-    ) -> Result<Vec<Entitlement>> {
+    ) -> Result<Vec<T>> {
         let (user_id_str, sku_ids_str, before_str, after_str, limit_str, guild_id_str, exclude_str);
         let mut params = ArrayVec::<_, 7>::new();
         if let Some(user_id) = user_id {
@@ -3093,7 +3115,7 @@ impl Http {
     }
 
     /// Gets current gateway.
-    pub async fn get_gateway(&self) -> Result<Gateway> {
+    pub async fn get_gateway<T: DeserializeOwned>(&self) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3106,7 +3128,7 @@ impl Http {
     }
 
     /// Fetches all of the global commands for your application.
-    pub async fn get_global_commands(&self) -> Result<Vec<Command>> {
+    pub async fn get_global_commands<T: DeserializeOwned>(&self) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3121,7 +3143,9 @@ impl Http {
     }
 
     /// Fetches all of the global commands for your application with localizations.
-    pub async fn get_global_commands_with_localizations(&self) -> Result<Vec<Command>> {
+    pub async fn get_global_commands_with_localizations<T: DeserializeOwned>(
+        &self,
+    ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3136,7 +3160,10 @@ impl Http {
     }
 
     /// Fetches a global commands for your application by its Id.
-    pub async fn get_global_command(&self, command_id: CommandId) -> Result<Command> {
+    pub async fn get_global_command<T: DeserializeOwned>(
+        &self,
+        command_id: CommandId,
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3152,7 +3179,7 @@ impl Http {
     }
 
     /// Gets guild information.
-    pub async fn get_guild(&self, guild_id: GuildId) -> Result<PartialGuild> {
+    pub async fn get_guild<T: DeserializeOwned>(&self, guild_id: GuildId) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3167,7 +3194,7 @@ impl Http {
     }
 
     /// Gets guild information with counts.
-    pub async fn get_guild_with_counts(&self, guild_id: GuildId) -> Result<PartialGuild> {
+    pub async fn get_guild_with_counts<T: DeserializeOwned>(&self, guild_id: GuildId) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3182,7 +3209,10 @@ impl Http {
     }
 
     /// Fetches all of the guild commands for your application for a specific guild.
-    pub async fn get_guild_commands(&self, guild_id: GuildId) -> Result<Vec<Command>> {
+    pub async fn get_guild_commands<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+    ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3199,10 +3229,10 @@ impl Http {
 
     /// Fetches all of the guild commands with localizations for your application for a specific
     /// guild.
-    pub async fn get_guild_commands_with_localizations(
+    pub async fn get_guild_commands_with_localizations<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-    ) -> Result<Vec<Command>> {
+    ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3218,11 +3248,11 @@ impl Http {
     }
 
     /// Fetches a guild command by its Id.
-    pub async fn get_guild_command(
+    pub async fn get_guild_command<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         command_id: CommandId,
-    ) -> Result<Command> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3239,10 +3269,10 @@ impl Http {
     }
 
     /// Fetches all of the guild commands permissions for your application for a specific guild.
-    pub async fn get_guild_commands_permissions(
+    pub async fn get_guild_commands_permissions<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-    ) -> Result<Vec<CommandPermissions>> {
+    ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3258,11 +3288,11 @@ impl Http {
     }
 
     /// Gives the guild command permission for your application for a specific guild.
-    pub async fn get_guild_command_permissions(
+    pub async fn get_guild_command_permissions<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         command_id: CommandId,
-    ) -> Result<CommandPermissions> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3279,7 +3309,7 @@ impl Http {
     }
 
     /// Gets a guild widget information.
-    pub async fn get_guild_widget(&self, guild_id: GuildId) -> Result<GuildWidget> {
+    pub async fn get_guild_widget<T: DeserializeOwned>(&self, guild_id: GuildId) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3294,7 +3324,7 @@ impl Http {
     }
 
     /// Gets a guild preview.
-    pub async fn get_guild_preview(&self, guild_id: GuildId) -> Result<GuildPreview> {
+    pub async fn get_guild_preview<T: DeserializeOwned>(&self, guild_id: GuildId) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3309,7 +3339,10 @@ impl Http {
     }
 
     /// Gets a guild welcome screen information.
-    pub async fn get_guild_welcome_screen(&self, guild_id: GuildId) -> Result<GuildWelcomeScreen> {
+    pub async fn get_guild_welcome_screen<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3324,7 +3357,10 @@ impl Http {
     }
 
     /// Gets integrations that a guild has.
-    pub async fn get_guild_integrations(&self, guild_id: GuildId) -> Result<Vec<Integration>> {
+    pub async fn get_guild_integrations<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+    ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3339,7 +3375,10 @@ impl Http {
     }
 
     /// Gets all invites to a guild.
-    pub async fn get_guild_invites(&self, guild_id: GuildId) -> Result<Vec<Invite>> {
+    pub async fn get_guild_invites<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+    ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3354,34 +3393,34 @@ impl Http {
     }
 
     /// Gets a guild's vanity URL if it has one.
-    pub async fn get_guild_vanity_url(&self, guild_id: GuildId) -> Result<String> {
-        #[derive(Deserialize)]
-        struct GuildVanityUrl {
-            code: String,
-        }
+    pub async fn get_guild_vanity_url<T: DeserializeOwned>(&self, guild_id: GuildId) -> Result<T> {
+        let resp = self
+            .fire::<Value>(Request {
+                body: None,
+                multipart: None,
+                headers: None,
+                method: LightMethod::Get,
+                route: Route::GuildVanityUrl {
+                    guild_id,
+                },
+                params: None,
+            })
+            .await?
+            .get_mut("code")
+            .map(Value::take)
+            .unwrap_or_default();
 
-        self.fire(Request {
-            body: None,
-            multipart: None,
-            headers: None,
-            method: LightMethod::Get,
-            route: Route::GuildVanityUrl {
-                guild_id,
-            },
-            params: None,
-        })
-        .await
-        .map(|x: GuildVanityUrl| x.code)
+        from_value(resp).map_err(From::from)
     }
 
     /// Gets the members of a guild. Optionally pass a `limit` and the Id of the user to offset the
     /// result by.
-    pub async fn get_guild_members(
+    pub async fn get_guild_members<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         limit: Option<NonMaxU16>,
         after: Option<UserId>,
-    ) -> Result<Vec<Member>> {
+    ) -> Result<Vec<T>> {
         let (limit_str, after_str);
         let mut params = ArrayVec::<_, 2>::new();
 
@@ -3418,7 +3457,11 @@ impl Http {
     }
 
     /// Gets the amount of users that can be pruned.
-    pub async fn get_guild_prune_count(&self, guild_id: GuildId, days: u8) -> Result<GuildPrune> {
+    pub async fn get_guild_prune_count<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+        days: u8,
+    ) -> Result<T> {
         let days_str = days.to_arraystring();
         self.fire(Request {
             body: None,
@@ -3435,7 +3478,10 @@ impl Http {
 
     /// Gets regions that a guild can use. If a guild has the `VIP_REGIONS` feature enabled, then
     /// additional VIP-only regions are returned.
-    pub async fn get_guild_regions(&self, guild_id: GuildId) -> Result<Vec<VoiceRegion>> {
+    pub async fn get_guild_regions<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+    ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3450,7 +3496,11 @@ impl Http {
     }
 
     /// Retrieves a specific role in a [`Guild`].
-    pub async fn get_guild_role(&self, guild_id: GuildId, role_id: RoleId) -> Result<Role> {
+    pub async fn get_guild_role<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+        role_id: RoleId,
+    ) -> Result<T> {
         let mut value: Value = self
             .fire(Request {
                 body: None,
@@ -3494,7 +3544,10 @@ impl Http {
     }
 
     /// Retrieves a list of roles in a [`Guild`].
-    pub async fn get_guild_roles(&self, guild_id: GuildId) -> Result<ExtractMap<RoleId, Role>> {
+    pub async fn get_guild_roles<T: DeserializeOwned + ExtractKey<RoleId>>(
+        &self,
+        guild_id: GuildId,
+    ) -> Result<ExtractMap<RoleId, T>> {
         let mut value: Value = self
             .fire(Request {
                 body: None,
@@ -3520,12 +3573,12 @@ impl Http {
     }
 
     /// Gets a scheduled event by Id.
-    pub async fn get_scheduled_event(
+    pub async fn get_scheduled_event<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         event_id: ScheduledEventId,
         with_user_count: bool,
-    ) -> Result<ScheduledEvent> {
+    ) -> Result<T> {
         let with_user_count_str = with_user_count.to_arraystring();
         self.fire(Request {
             body: None,
@@ -3542,11 +3595,11 @@ impl Http {
     }
 
     /// Gets a list of all scheduled events for the corresponding guild.
-    pub async fn get_scheduled_events(
+    pub async fn get_scheduled_events<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         with_user_count: bool,
-    ) -> Result<Vec<ScheduledEvent>> {
+    ) -> Result<Vec<T>> {
         let with_user_count_str = with_user_count.to_arraystring();
         self.fire(Request {
             body: None,
@@ -3563,14 +3616,14 @@ impl Http {
 
     /// Gets a list of all interested users for the corresponding scheduled event, with additional
     /// options for filtering.
-    pub async fn get_scheduled_event_users(
+    pub async fn get_scheduled_event_users<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         event_id: ScheduledEventId,
         limit: Option<NonMaxU8>,
         target: Option<UserPagination>,
         with_member: Option<bool>,
-    ) -> Result<Vec<ScheduledEventUser>> {
+    ) -> Result<Vec<T>> {
         let (limit_str, with_member_str, id_str);
         let mut params = ArrayVec::<_, 3>::new();
         if let Some(limit) = limit {
@@ -3606,7 +3659,10 @@ impl Http {
     }
 
     /// Retrieves a list of stickers in a [`Guild`].
-    pub async fn get_guild_stickers(&self, guild_id: GuildId) -> Result<Vec<Sticker>> {
+    pub async fn get_guild_stickers<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+    ) -> Result<Vec<T>> {
         let mut value: Value = self
             .fire(Request {
                 body: None,
@@ -3632,11 +3688,11 @@ impl Http {
     }
 
     /// Retrieves a single sticker in a [`Guild`].
-    pub async fn get_guild_sticker(
+    pub async fn get_guild_sticker<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         sticker_id: StickerId,
-    ) -> Result<Sticker> {
+    ) -> Result<T> {
         let mut value: Value = self
             .fire(Request {
                 body: None,
@@ -3659,7 +3715,10 @@ impl Http {
     }
 
     /// Retrieves the webhooks for the given [`Guild`]'s Id.
-    pub async fn get_guild_webhooks(&self, guild_id: GuildId) -> Result<Vec<Webhook>> {
+    pub async fn get_guild_webhooks<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+    ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3676,11 +3735,11 @@ impl Http {
     /// Gets a paginated list of the current user's guilds.
     ///
     /// The `limit` has a maximum value of 200.
-    pub async fn get_guilds(
+    pub async fn get_guilds<T: DeserializeOwned>(
         &self,
         target: Option<GuildPagination>,
         limit: Option<NonMaxU8>,
-    ) -> Result<Vec<GuildInfo>> {
+    ) -> Result<Vec<T>> {
         let (limit_str, id_str);
         let mut params = ArrayVec::<_, 2>::new();
         if let Some(limit) = limit {
@@ -3713,7 +3772,10 @@ impl Http {
     /// This method only works for user tokens with the [`GuildsMembersRead`] OAuth2 scope.
     ///
     /// [`GuildsMembersRead`]: crate::model::application::Scope::GuildsMembersRead
-    pub async fn get_current_user_guild_member(&self, guild_id: GuildId) -> Result<Member> {
+    pub async fn get_current_user_guild_member<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+    ) -> Result<T> {
         let mut value: Value = self
             .fire(Request {
                 body: None,
@@ -3735,12 +3797,12 @@ impl Http {
     }
 
     /// Gets information about a specific invite.
-    pub async fn get_invite(
+    pub async fn get_invite<T: DeserializeOwned>(
         &self,
         code: &str,
         member_counts: bool,
         event_id: Option<ScheduledEventId>,
-    ) -> Result<Invite> {
+    ) -> Result<T> {
         let (member_counts_str, event_id_str);
         let mut params = ArrayVec::<_, 2>::new();
 
@@ -3766,7 +3828,11 @@ impl Http {
     }
 
     /// Gets member of a guild.
-    pub async fn get_member(&self, guild_id: GuildId, user_id: UserId) -> Result<Member> {
+    pub async fn get_member<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+        user_id: UserId,
+    ) -> Result<T> {
         let mut value: Value = self
             .fire(Request {
                 body: None,
@@ -3789,11 +3855,11 @@ impl Http {
     }
 
     /// Gets a message by an Id, bots only.
-    pub async fn get_message(
+    pub async fn get_message<T: DeserializeOwned>(
         &self,
         channel_id: GenericChannelId,
         message_id: MessageId,
-    ) -> Result<Message> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3809,12 +3875,12 @@ impl Http {
     }
 
     /// Gets X messages from a channel.
-    pub async fn get_messages(
+    pub async fn get_messages<T: DeserializeOwned>(
         &self,
         channel_id: GenericChannelId,
         target: Option<MessagePagination>,
         limit: Option<NonMaxU8>,
-    ) -> Result<Vec<Message>> {
+    ) -> Result<Vec<T>> {
         let (limit_str, id_str);
         let mut params = ArrayVec::<_, 2>::new();
 
@@ -3848,7 +3914,10 @@ impl Http {
     }
 
     /// Retrieves a specific [`StickerPack`] from it's [`StickerPackId`]
-    pub async fn get_sticker_pack(&self, sticker_pack_id: StickerPackId) -> Result<StickerPack> {
+    pub async fn get_sticker_pack<T: DeserializeOwned>(
+        &self,
+        sticker_pack_id: StickerPackId,
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3863,31 +3932,31 @@ impl Http {
     }
 
     /// Retrieves a list of all nitro sticker packs.
-    pub async fn get_nitro_stickers(&self) -> Result<Vec<StickerPack>> {
-        #[derive(Deserialize)]
-        struct StickerPacks {
-            sticker_packs: Vec<StickerPack>,
-        }
+    pub async fn get_nitro_stickers<T: DeserializeOwned>(&self) -> Result<Vec<T>> {
+        let resp = self
+            .fire::<Value>(Request {
+                body: None,
+                multipart: None,
+                headers: None,
+                method: LightMethod::Get,
+                route: Route::StickerPacks,
+                params: None,
+            })
+            .await?
+            .get_mut("sticker_packs")
+            .map(Value::take)
+            .unwrap_or_default();
 
-        self.fire(Request {
-            body: None,
-            multipart: None,
-            headers: None,
-            method: LightMethod::Get,
-            route: Route::StickerPacks,
-            params: None,
-        })
-        .await
-        .map(|s: StickerPacks| s.sticker_packs)
+        from_value(resp).map_err(From::from)
     }
 
     /// Gets all pins of a channel.
-    pub async fn get_pins(
+    pub async fn get_pins<T: DeserializeOwned>(
         &self,
         channel_id: GenericChannelId,
         before: Option<Timestamp>,
         limit: Option<u8>,
-    ) -> Result<MessagePinsPage> {
+    ) -> Result<T> {
         let (before_str, limit_str);
         let mut params = ArrayVec::<_, 2>::new();
 
@@ -3915,7 +3984,7 @@ impl Http {
     }
 
     /// Gets a list of users who reacted with an emoji.
-    pub async fn get_reaction_users(
+    pub async fn get_reaction_users<T: DeserializeOwned>(
         &self,
         channel_id: GenericChannelId,
         message_id: MessageId,
@@ -3923,7 +3992,7 @@ impl Http {
         reaction_type: Option<ReactionTypes>,
         limit: Option<NonMaxU8>,
         after: Option<UserId>,
-    ) -> Result<Vec<User>> {
+    ) -> Result<Vec<T>> {
         let (type_str, limit_str, after_str);
         let mut params = ArrayVec::<_, 3>::new();
 
@@ -3958,7 +4027,7 @@ impl Http {
     }
 
     /// Gets all SKUs for the current application.
-    pub async fn get_skus(&self) -> Result<Vec<Sku>> {
+    pub async fn get_skus<T: DeserializeOwned>(&self) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3973,7 +4042,7 @@ impl Http {
     }
 
     /// Gets a sticker.
-    pub async fn get_sticker(&self, sticker_id: StickerId) -> Result<Sticker> {
+    pub async fn get_sticker<T: DeserializeOwned>(&self, sticker_id: StickerId) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3990,15 +4059,9 @@ impl Http {
     /// Gets the current unresolved incidents from Discord's Status API.
     ///
     /// Does not require authentication.
-    pub async fn get_unresolved_incidents(&self) -> Result<Vec<Incident>> {
-        #[derive(Deserialize)]
-        struct StatusResponse {
-            #[serde(default)]
-            incidents: Vec<Incident>,
-        }
-
-        let status: StatusResponse = self
-            .fire(Request {
+    pub async fn get_unresolved_incidents<T: DeserializeOwned>(&self) -> Result<Vec<T>> {
+        let status = self
+            .fire::<Value>(Request {
                 body: None,
                 multipart: None,
                 headers: None,
@@ -4006,23 +4069,22 @@ impl Http {
                 route: Route::StatusIncidentsUnresolved,
                 params: None,
             })
-            .await?;
+            .await?
+            .get_mut("incidents")
+            .map(Value::take);
 
-        Ok(status.incidents)
+        match status {
+            Some(status) => from_value(status).map_err(From::from),
+            None => Ok(vec![]),
+        }
     }
 
     /// Gets the upcoming (planned) maintenances from Discord's Status API.
     ///
     /// Does not require authentication.
-    pub async fn get_upcoming_maintenances(&self) -> Result<Vec<Maintenance>> {
-        #[derive(Deserialize)]
-        struct StatusResponse {
-            #[serde(default)]
-            scheduled_maintenances: Vec<Maintenance>,
-        }
-
-        let status: StatusResponse = self
-            .fire(Request {
+    pub async fn get_upcoming_maintenances<T: DeserializeOwned>(&self) -> Result<Vec<T>> {
+        let status = self
+            .fire::<Value>(Request {
                 body: None,
                 multipart: None,
                 headers: None,
@@ -4030,13 +4092,18 @@ impl Http {
                 route: Route::StatusMaintenancesUpcoming,
                 params: None,
             })
-            .await?;
+            .await?
+            .get_mut("scheduled_maintenances")
+            .map(Value::take);
 
-        Ok(status.scheduled_maintenances)
+        match status {
+            Some(status) => from_value(status).map_err(From::from),
+            None => Ok(vec![]),
+        }
     }
 
     /// Gets a user by Id.
-    pub async fn get_user(&self, user_id: UserId) -> Result<User> {
+    pub async fn get_user<T: DeserializeOwned>(&self, user_id: UserId) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -4055,7 +4122,7 @@ impl Http {
     /// This method only works for user tokens with the [`Connections`] OAuth2 scope.
     ///
     /// [`Connections`]: crate::model::application::Scope::Connections
-    pub async fn get_user_connections(&self) -> Result<Vec<Connection>> {
+    pub async fn get_user_connections<T: DeserializeOwned>(&self) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -4068,7 +4135,7 @@ impl Http {
     }
 
     /// Gets our DM channels.
-    pub async fn get_user_dm_channels(&self) -> Result<Vec<PrivateChannel>> {
+    pub async fn get_user_dm_channels<T: DeserializeOwned>(&self) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -4081,7 +4148,7 @@ impl Http {
     }
 
     /// Gets all voice regions.
-    pub async fn get_voice_regions(&self) -> Result<Vec<VoiceRegion>> {
+    pub async fn get_voice_regions<T: DeserializeOwned>(&self) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -4095,11 +4162,11 @@ impl Http {
 
     /// Get User Voice State
     /// Returns the specified user's voice state in the guild.
-    pub async fn get_user_voice_state(
+    pub async fn get_user_voice_state<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         user_id: UserId,
-    ) -> Result<VoiceState> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -4118,7 +4185,7 @@ impl Http {
     ///
     /// This method requires authentication, whereas [`Http::get_webhook_with_token`] and
     /// [`Http::get_webhook_from_url`] do not.
-    pub async fn get_webhook(&self, webhook_id: WebhookId) -> Result<Webhook> {
+    pub async fn get_webhook<T: DeserializeOwned>(&self, webhook_id: WebhookId) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -4135,11 +4202,11 @@ impl Http {
     /// Retrieves a webhook given its Id and unique token.
     ///
     /// This method does _not_ require authentication.
-    pub async fn get_webhook_with_token(
+    pub async fn get_webhook_with_token<T: DeserializeOwned>(
         &self,
         webhook_id: WebhookId,
         token: &str,
-    ) -> Result<Webhook> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -4158,7 +4225,7 @@ impl Http {
     ///
     /// This method does _not_ require authentication
     #[cfg(feature = "utils")]
-    pub async fn get_webhook_from_url(&self, url: &str) -> Result<Webhook> {
+    pub async fn get_webhook_from_url<T: DeserializeOwned>(&self, url: &str) -> Result<T> {
         let url = Url::parse(url)?;
         let (webhook_id, token) =
             crate::utils::parse_webhook(&url).ok_or(HttpError::InvalidWebhook)?;
@@ -4213,12 +4280,12 @@ impl Http {
     }
 
     /// Sends a message to a channel.
-    pub async fn send_message(
+    pub async fn send_message<T: DeserializeOwned>(
         &self,
         channel_id: GenericChannelId,
         files: Vec<AttachmentData<'_>>,
-        map: &impl serde::Serialize,
-    ) -> Result<Message> {
+        map: &impl Serialize,
+    ) -> Result<T> {
         let mut request = Request {
             body: None,
             multipart: None,
@@ -4310,12 +4377,12 @@ impl Http {
 
     /// Returns a list of [`Member`]s in a [`Guild`] whose username or nickname starts with a
     /// provided string.
-    pub async fn search_guild_members(
+    pub async fn search_guild_members<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         query: &str,
         limit: Option<NonMaxU16>,
-    ) -> Result<Vec<Member>> {
+    ) -> Result<Vec<T>> {
         let limit_str = limit.unwrap_or(constants::MEMBER_FETCH_LIMIT).get().to_arraystring();
         let mut value: Value = self
             .fire(Request {
@@ -4342,12 +4409,12 @@ impl Http {
     }
 
     /// Starts removing some members from a guild based on the last time they've been online.
-    pub async fn start_guild_prune(
+    pub async fn start_guild_prune<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         days: u8,
         audit_log_reason: Option<&str>,
-    ) -> Result<GuildPrune> {
+    ) -> Result<T> {
         let days_str = days.to_arraystring();
         self.fire(Request {
             body: None,
@@ -4387,11 +4454,11 @@ impl Http {
     /// **Note**: Requires the [Manage Guild] permission.
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
-    pub async fn edit_guild_incident_actions(
+    pub async fn edit_guild_incident_actions<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
-    ) -> Result<IncidentsData> {
+        map: &impl Serialize,
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -4430,7 +4497,7 @@ impl Http {
     pub async fn send_soundboard_sound(
         &self,
         channel_id: ChannelId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
     ) -> Result<()> {
         self.wind(Request {
             body: Some(to_vec(map)?),
@@ -4446,7 +4513,7 @@ impl Http {
     }
 
     /// Retrieves a list of soundboard sounds that anyone can use.
-    pub async fn list_default_soundboard_sounds(&self) -> Result<Vec<Soundboard>> {
+    pub async fn list_default_soundboard_sounds<T: DeserializeOwned>(&self) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -4459,14 +4526,12 @@ impl Http {
     }
 
     /// Retrieves soundboard sounds from a guild.
-    pub async fn get_guild_soundboards(&self, guild_id: GuildId) -> Result<Vec<Soundboard>> {
-        #[derive(serde::Deserialize)]
-        struct SoundboardList {
-            items: Vec<Soundboard>,
-        }
-
-        let result: SoundboardList = self
-            .fire(Request {
+    pub async fn get_guild_soundboards<T: DeserializeOwned>(
+        &self,
+        guild_id: GuildId,
+    ) -> Result<Vec<T>> {
+        let result = self
+            .fire::<Value>(Request {
                 body: None,
                 multipart: None,
                 headers: None,
@@ -4476,17 +4541,20 @@ impl Http {
                 },
                 params: None,
             })
-            .await?;
+            .await?
+            .get_mut("items")
+            .map(Value::take)
+            .unwrap_or_default();
 
-        Ok(result.items)
+        from_value(result).map_err(From::from)
     }
 
     /// Retrieves a soundboard sound from a guild.
-    pub async fn get_guild_soundboard(
+    pub async fn get_guild_soundboard<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         sound_id: SoundId,
-    ) -> Result<Soundboard> {
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -4502,12 +4570,12 @@ impl Http {
     }
 
     /// Creates a soundboard sound in a guild.
-    pub async fn create_guild_soundboard(
+    pub async fn create_guild_soundboard<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<Soundboard> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -4522,13 +4590,13 @@ impl Http {
     }
 
     /// Edits a soundboard sound in a guild.
-    pub async fn edit_guild_soundboard(
+    pub async fn edit_guild_soundboard<T: DeserializeOwned>(
         &self,
         guild_id: GuildId,
         sound_id: SoundId,
-        map: &impl serde::Serialize,
+        map: &impl Serialize,
         audit_log_reason: Option<&str>,
-    ) -> Result<Soundboard> {
+    ) -> Result<T> {
         self.fire(Request {
             body: Some(to_vec(map)?),
             multipart: None,

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -3,6 +3,7 @@
 use std::borrow::Cow;
 use std::cell::Cell;
 use std::collections::HashMap;
+use std::hash::Hash;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use arrayvec::ArrayVec;
@@ -24,14 +25,7 @@ use super::multipart::{Multipart, MultipartUpload};
 use super::ratelimiting::Ratelimiter;
 use super::request::Request;
 use super::routing::Route;
-use super::{
-    ErrorResponse,
-    GuildPagination,
-    HttpError,
-    LightMethod,
-    MessagePagination,
-    UserPagination,
-};
+use super::{ErrorResponse, HttpError, LightMethod, MessagePagination, Pagination};
 use crate::builder::{AttachmentData, CreateAllowedMentions};
 use crate::constants;
 use crate::model::prelude::*;
@@ -84,7 +78,7 @@ pub struct HttpBuilder {
     ratelimiter_disabled: bool,
     token: Option<Token>,
     proxy: Option<FixedString<u16>>,
-    application_id: Option<ApplicationId>,
+    application_id: Option<Snowflake>,
     default_allowed_mentions: Option<CreateAllowedMentions<'static>>,
 }
 
@@ -119,7 +113,7 @@ impl HttpBuilder {
     }
 
     /// Sets the application_id to use interactions.
-    pub fn application_id(mut self, application_id: ApplicationId) -> Self {
+    pub fn application_id(mut self, application_id: Snowflake) -> Self {
         self.application_id = Some(application_id);
         self
     }
@@ -193,8 +187,7 @@ impl HttpBuilder {
     /// Use the given configuration to build the `Http` client.
     #[must_use]
     pub fn build(self) -> Http {
-        let application_id =
-            AtomicU64::new(self.application_id.map_or(u64::MAX, ApplicationId::get));
+        let application_id = AtomicU64::new(self.application_id.map_or(u64::MAX, Snowflake::get));
 
         let client = self.client.unwrap_or_else(|| {
             let builder = configure_client_backend(Client::builder());
@@ -261,16 +254,16 @@ impl Http {
         HttpBuilder::without_token().build()
     }
 
-    pub fn application_id(&self) -> Option<ApplicationId> {
+    pub fn application_id(&self) -> Option<Snowflake> {
         let application_id = self.application_id.load(Ordering::Acquire);
-        if application_id == u64::MAX { None } else { Some(ApplicationId::new(application_id)) }
+        if application_id == u64::MAX { None } else { Some(Snowflake::new(application_id)) }
     }
 
-    fn try_application_id(&self) -> Result<ApplicationId> {
+    fn try_application_id(&self) -> Result<Snowflake> {
         self.application_id().ok_or_else(|| HttpError::ApplicationIdMissing.into())
     }
 
-    pub fn set_application_id(&self, application_id: ApplicationId) {
+    pub fn set_application_id(&self, application_id: Snowflake) {
         self.application_id.store(application_id.get(), Ordering::Release);
     }
 
@@ -279,8 +272,8 @@ impl Http {
     /// Returns the created [`Member`] object, or nothing if the user is already a guild member.
     pub async fn add_guild_member<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
-        user_id: UserId,
+        guild_id: Snowflake,
+        user_id: Snowflake,
         map: &impl Serialize,
     ) -> Result<Option<T>> {
         let response = self
@@ -303,9 +296,9 @@ impl Http {
     /// Adds a single [`Role`] to a [`Member`] in a [`Guild`].
     pub async fn add_member_role(
         &self,
-        guild_id: GuildId,
-        user_id: UserId,
-        role_id: RoleId,
+        guild_id: Snowflake,
+        user_id: Snowflake,
+        role_id: Snowflake,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
         self.wind(Request {
@@ -330,8 +323,8 @@ impl Http {
     /// `604800` seconds (or 7 days) worth of messages may be deleted.
     pub async fn ban_user(
         &self,
-        guild_id: GuildId,
-        user_id: UserId,
+        guild_id: Snowflake,
+        user_id: Snowflake,
         delete_message_seconds: u32,
         reason: Option<&str>,
     ) -> Result<()> {
@@ -355,7 +348,7 @@ impl Http {
     /// for more information.
     pub async fn bulk_ban_users<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
         map: &impl Serialize,
         reason: Option<&str>,
     ) -> Result<T> {
@@ -373,7 +366,7 @@ impl Http {
     }
 
     /// Broadcasts that the current user is typing in the given [`Channel`].
-    pub async fn broadcast_typing(&self, channel_id: GenericChannelId) -> Result<()> {
+    pub async fn broadcast_typing(&self, channel_id: Snowflake) -> Result<()> {
         self.wind(Request {
             body: None,
             multipart: None,
@@ -390,7 +383,7 @@ impl Http {
     /// Creates a [`GuildChannel`] in the [`Guild`] given its Id.
     pub async fn create_channel<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<T> {
@@ -427,8 +420,8 @@ impl Http {
     /// Creates a thread channel in the [`GuildChannel`] given its Id, with a base message Id.
     pub async fn create_thread_from_message<T: DeserializeOwned>(
         &self,
-        channel_id: ChannelId,
-        message_id: MessageId,
+        channel_id: Snowflake,
+        message_id: Snowflake,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<T> {
@@ -449,7 +442,7 @@ impl Http {
     /// Creates a thread channel not attached to a message in the [`GuildChannel`] given its Id.
     pub async fn create_thread<T: DeserializeOwned>(
         &self,
-        channel_id: ChannelId,
+        channel_id: Snowflake,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<T> {
@@ -469,7 +462,7 @@ impl Http {
     /// Creates a forum post channel in the [`GuildChannel`] given its Id.
     pub async fn create_forum_post<T: DeserializeOwned>(
         &self,
-        channel_id: ChannelId,
+        channel_id: Snowflake,
         map: &impl Serialize,
         files: Vec<AttachmentData<'_>>,
         audit_log_reason: Option<&str>,
@@ -494,7 +487,7 @@ impl Http {
     /// Creates an emoji in the given [`Guild`] with the given data.
     pub async fn create_emoji<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<T> {
@@ -606,7 +599,7 @@ impl Http {
     /// Creates new guild application commands.
     pub async fn create_guild_commands<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
         map: &impl Serialize,
     ) -> Result<T> {
         self.fire(Request {
@@ -647,7 +640,7 @@ impl Http {
     /// New guild commands will be available in the guild immediately.
     pub async fn create_guild_command<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
         map: &impl Serialize,
     ) -> Result<T> {
         self.fire(Request {
@@ -667,8 +660,8 @@ impl Http {
     /// Creates an [`Integration`] for a [`Guild`].
     pub async fn create_guild_integration(
         &self,
-        guild_id: GuildId,
-        integration_id: IntegrationId,
+        guild_id: Snowflake,
+        integration_id: Snowflake,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
@@ -689,7 +682,7 @@ impl Http {
     /// Creates a response to an [`Interaction`] from the gateway.
     pub async fn create_interaction_response(
         &self,
-        interaction_id: InteractionId,
+        interaction_id: Snowflake,
         interaction_token: &str,
         map: &impl Serialize,
         files: Vec<AttachmentData<'_>>,
@@ -722,7 +715,7 @@ impl Http {
     /// Creates an [`Invite`] for the given [channel][`GuildChannel`].
     pub async fn create_invite<T: DeserializeOwned>(
         &self,
-        channel_id: ChannelId,
+        channel_id: Snowflake,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<T> {
@@ -742,8 +735,8 @@ impl Http {
     /// Creates a permission override for a member or a role in a channel.
     pub async fn create_permission(
         &self,
-        channel_id: ChannelId,
-        target_id: TargetId,
+        channel_id: Snowflake,
+        target_id: Snowflake,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
@@ -780,8 +773,8 @@ impl Http {
     /// Reacts to a message.
     pub async fn create_reaction(
         &self,
-        channel_id: GenericChannelId,
-        message_id: MessageId,
+        channel_id: Snowflake,
+        message_id: Snowflake,
         reaction: &str,
     ) -> Result<()> {
         self.wind(Request {
@@ -802,7 +795,7 @@ impl Http {
     /// Creates a role.
     pub async fn create_role<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<T> {
@@ -829,7 +822,7 @@ impl Http {
     /// Creates a Guild Scheduled Event.
     pub async fn create_scheduled_event<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<T> {
@@ -849,7 +842,7 @@ impl Http {
     /// Creates a sticker.
     pub async fn create_sticker<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
         fields: Vec<(Cow<'static, str>, Cow<'static, str>)>,
         file: AttachmentData<'_>,
         audit_log_reason: Option<&str>,
@@ -894,7 +887,7 @@ impl Http {
     /// Creates a webhook for the given [`GuildChannel`]'s Id, passing in the given data.
     pub async fn create_webhook<T: DeserializeOwned>(
         &self,
-        channel_id: ChannelId,
+        channel_id: Snowflake,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<T> {
@@ -914,7 +907,7 @@ impl Http {
     /// Deletes a private channel or a channel in a guild.
     pub async fn delete_channel<T: DeserializeOwned>(
         &self,
-        channel_id: GenericChannelId,
+        channel_id: Snowflake,
         audit_log_reason: Option<&str>,
     ) -> Result<T> {
         self.fire(Request {
@@ -933,7 +926,7 @@ impl Http {
     /// Deletes a stage instance.
     pub async fn delete_stage_instance(
         &self,
-        channel_id: ChannelId,
+        channel_id: Snowflake,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
         self.wind(Request {
@@ -952,8 +945,8 @@ impl Http {
     /// Deletes an emoji from a guild.
     pub async fn delete_emoji(
         &self,
-        guild_id: GuildId,
-        emoji_id: EmojiId,
+        guild_id: Snowflake,
+        emoji_id: Snowflake,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
         self.wind(Request {
@@ -971,7 +964,7 @@ impl Http {
     }
 
     /// Deletes an application emoji.
-    pub async fn delete_application_emoji(&self, emoji_id: EmojiId) -> Result<()> {
+    pub async fn delete_application_emoji(&self, emoji_id: Snowflake) -> Result<()> {
         self.wind(Request {
             body: None,
             multipart: None,
@@ -990,7 +983,7 @@ impl Http {
     pub async fn delete_followup_message(
         &self,
         interaction_token: &str,
-        message_id: MessageId,
+        message_id: Snowflake,
     ) -> Result<()> {
         self.wind(Request {
             body: None,
@@ -1008,7 +1001,7 @@ impl Http {
     }
 
     /// Deletes a global command.
-    pub async fn delete_global_command(&self, command_id: CommandId) -> Result<()> {
+    pub async fn delete_global_command(&self, command_id: Snowflake) -> Result<()> {
         self.wind(Request {
             body: None,
             multipart: None,
@@ -1024,7 +1017,7 @@ impl Http {
     }
 
     /// Deletes a guild, only if connected account owns it.
-    pub async fn delete_guild(&self, guild_id: GuildId) -> Result<()> {
+    pub async fn delete_guild(&self, guild_id: Snowflake) -> Result<()> {
         self.wind(Request {
             body: None,
             multipart: None,
@@ -1041,8 +1034,8 @@ impl Http {
     /// Deletes a guild command.
     pub async fn delete_guild_command(
         &self,
-        guild_id: GuildId,
-        command_id: CommandId,
+        guild_id: Snowflake,
+        command_id: Snowflake,
     ) -> Result<()> {
         self.wind(Request {
             body: None,
@@ -1062,8 +1055,8 @@ impl Http {
     /// Removes an integration from a guild.
     pub async fn delete_guild_integration(
         &self,
-        guild_id: GuildId,
-        integration_id: IntegrationId,
+        guild_id: Snowflake,
+        integration_id: Snowflake,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
         self.wind(Request {
@@ -1102,8 +1095,8 @@ impl Http {
     /// Deletes a message if created by us or we have specific permissions.
     pub async fn delete_message(
         &self,
-        channel_id: GenericChannelId,
-        message_id: MessageId,
+        channel_id: Snowflake,
+        message_id: Snowflake,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
         self.wind(Request {
@@ -1123,7 +1116,7 @@ impl Http {
     /// Deletes a bunch of messages, only works for bots.
     pub async fn delete_messages(
         &self,
-        channel_id: GenericChannelId,
+        channel_id: Snowflake,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
@@ -1143,8 +1136,8 @@ impl Http {
     /// Deletes all of the [`Reaction`]s associated with a [`Message`].
     pub async fn delete_message_reactions(
         &self,
-        channel_id: GenericChannelId,
-        message_id: MessageId,
+        channel_id: Snowflake,
+        message_id: Snowflake,
     ) -> Result<()> {
         self.wind(Request {
             body: None,
@@ -1163,8 +1156,8 @@ impl Http {
     /// Deletes all the reactions for a given emoji on a message.
     pub async fn delete_message_reaction_emoji(
         &self,
-        channel_id: GenericChannelId,
-        message_id: MessageId,
+        channel_id: Snowflake,
+        message_id: Snowflake,
         reaction: &str,
     ) -> Result<()> {
         self.wind(Request {
@@ -1204,8 +1197,8 @@ impl Http {
     /// Deletes a permission override from a role or a member in a channel.
     pub async fn delete_permission(
         &self,
-        channel_id: ChannelId,
-        target_id: TargetId,
+        channel_id: Snowflake,
+        target_id: Snowflake,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
         self.wind(Request {
@@ -1225,9 +1218,9 @@ impl Http {
     /// Deletes a user's reaction from a message.
     pub async fn delete_reaction(
         &self,
-        channel_id: GenericChannelId,
-        message_id: MessageId,
-        user_id: UserId,
+        channel_id: Snowflake,
+        message_id: Snowflake,
+        user_id: Snowflake,
         reaction: &str,
     ) -> Result<()> {
         self.wind(Request {
@@ -1249,8 +1242,8 @@ impl Http {
     /// Deletes a reaction by the current user from a message.
     pub async fn delete_reaction_me(
         &self,
-        channel_id: GenericChannelId,
-        message_id: MessageId,
+        channel_id: Snowflake,
+        message_id: Snowflake,
         reaction: &str,
     ) -> Result<()> {
         self.wind(Request {
@@ -1271,8 +1264,8 @@ impl Http {
     /// Deletes a role from a server. Can't remove the default everyone role.
     pub async fn delete_role(
         &self,
-        guild_id: GuildId,
-        role_id: RoleId,
+        guild_id: Snowflake,
+        role_id: Snowflake,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
         self.wind(Request {
@@ -1292,8 +1285,8 @@ impl Http {
     /// Deletes a [Scheduled Event] from a server.
     pub async fn delete_scheduled_event(
         &self,
-        guild_id: GuildId,
-        event_id: ScheduledEventId,
+        guild_id: Snowflake,
+        event_id: Snowflake,
     ) -> Result<()> {
         self.wind(Request {
             body: None,
@@ -1312,8 +1305,8 @@ impl Http {
     /// Deletes a sticker from a server.
     pub async fn delete_sticker(
         &self,
-        guild_id: GuildId,
-        sticker_id: StickerId,
+        guild_id: Snowflake,
+        sticker_id: Snowflake,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
         self.wind(Request {
@@ -1332,7 +1325,7 @@ impl Http {
 
     /// Deletes a currently active test entitlement. Discord will act as though the corresponding
     /// user/guild *no longer has* an entitlement to the corresponding SKU.
-    pub async fn delete_test_entitlement(&self, entitlement_id: EntitlementId) -> Result<()> {
+    pub async fn delete_test_entitlement(&self, entitlement_id: Snowflake) -> Result<()> {
         self.wind(Request {
             body: None,
             multipart: None,
@@ -1350,7 +1343,7 @@ impl Http {
     /// Deletes a [`Webhook`] given its Id.
     pub async fn delete_webhook(
         &self,
-        webhook_id: WebhookId,
+        webhook_id: Snowflake,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
         self.wind(Request {
@@ -1371,7 +1364,7 @@ impl Http {
     /// This method does _not_ require authentication.
     pub async fn delete_webhook_with_token(
         &self,
-        webhook_id: WebhookId,
+        webhook_id: Snowflake,
         token: &str,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
@@ -1392,7 +1385,7 @@ impl Http {
     /// Changes channel information.
     pub async fn edit_channel<T: DeserializeOwned>(
         &self,
-        channel_id: GenericChannelId,
+        channel_id: Snowflake,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<T> {
@@ -1412,7 +1405,7 @@ impl Http {
     /// Edits a stage instance.
     pub async fn edit_stage_instance<T: DeserializeOwned>(
         &self,
-        channel_id: ChannelId,
+        channel_id: Snowflake,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<T> {
@@ -1432,8 +1425,8 @@ impl Http {
     /// Changes guild emoji information.
     pub async fn edit_emoji<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
-        emoji_id: EmojiId,
+        guild_id: Snowflake,
+        emoji_id: Snowflake,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<T> {
@@ -1458,7 +1451,7 @@ impl Http {
     /// [`Context::edit_application_emoji`]: crate::gateway::client::Context::edit_application_emoji
     pub async fn edit_application_emoji<T: DeserializeOwned>(
         &self,
-        emoji_id: EmojiId,
+        emoji_id: Snowflake,
         map: &impl Serialize,
     ) -> Result<T> {
         self.fire(Request {
@@ -1479,7 +1472,7 @@ impl Http {
     pub async fn edit_followup_message<T: DeserializeOwned>(
         &self,
         interaction_token: &str,
-        message_id: MessageId,
+        message_id: Snowflake,
         map: &impl Serialize,
         new_attachments: Vec<AttachmentData<'_>>,
     ) -> Result<T> {
@@ -1513,7 +1506,7 @@ impl Http {
     pub async fn get_followup_message<T: DeserializeOwned>(
         &self,
         interaction_token: &str,
-        message_id: MessageId,
+        message_id: Snowflake,
     ) -> Result<T> {
         self.fire(Request {
             body: None,
@@ -1533,7 +1526,7 @@ impl Http {
     /// Edits a global command.
     pub async fn edit_global_command<T: DeserializeOwned>(
         &self,
-        command_id: CommandId,
+        command_id: Snowflake,
         map: &impl Serialize,
     ) -> Result<T> {
         self.fire(Request {
@@ -1553,7 +1546,7 @@ impl Http {
     /// Changes guild information.
     pub async fn edit_guild<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<T> {
@@ -1573,8 +1566,8 @@ impl Http {
     /// Edits a guild command.
     pub async fn edit_guild_command<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
-        command_id: CommandId,
+        guild_id: Snowflake,
+        command_id: Snowflake,
         map: &impl Serialize,
     ) -> Result<T> {
         self.fire(Request {
@@ -1595,8 +1588,8 @@ impl Http {
     /// Edits a guild command permissions.
     pub async fn edit_guild_command_permissions<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
-        command_id: CommandId,
+        guild_id: Snowflake,
+        command_id: Snowflake,
         map: &impl Serialize,
     ) -> Result<T> {
         self.fire(Request {
@@ -1617,7 +1610,7 @@ impl Http {
     /// Edits the positions of a guild's channels.
     pub async fn edit_guild_channel_positions(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
         value: impl Iterator<Item: Serialize>,
     ) -> Result<()> {
         let body = to_vec(&SerializeIter::new(value))?;
@@ -1638,7 +1631,7 @@ impl Http {
     /// Edits the MFA level of a guild. Requires guild ownership.
     pub async fn edit_guild_mfa_level<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<T> {
@@ -1664,7 +1657,7 @@ impl Http {
     /// Edits a [`Guild`]'s widget.
     pub async fn edit_guild_widget<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<T> {
@@ -1684,7 +1677,7 @@ impl Http {
     /// Edits a guild welcome screen.
     pub async fn edit_guild_welcome_screen<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<T> {
@@ -1704,8 +1697,8 @@ impl Http {
     /// Does specific actions to a member.
     pub async fn edit_member<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
-        user_id: UserId,
+        guild_id: Snowflake,
+        user_id: Snowflake,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<T> {
@@ -1735,8 +1728,8 @@ impl Http {
     /// **Note**: Only the author of a message can modify it.
     pub async fn edit_message<T: DeserializeOwned>(
         &self,
-        channel_id: GenericChannelId,
-        message_id: MessageId,
+        channel_id: Snowflake,
+        message_id: Snowflake,
         map: &impl Serialize,
         new_attachments: Vec<AttachmentData<'_>>,
     ) -> Result<T> {
@@ -1770,8 +1763,8 @@ impl Http {
     /// **Note**: Only available on news channels.
     pub async fn crosspost_message<T: DeserializeOwned>(
         &self,
-        channel_id: ChannelId,
-        message_id: MessageId,
+        channel_id: Snowflake,
+        message_id: Snowflake,
     ) -> Result<T> {
         self.fire(Request {
             body: None,
@@ -1790,7 +1783,7 @@ impl Http {
     /// Edits the current member for the provided [`Guild`] via its Id.
     pub async fn edit_current_member<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<T> {
@@ -1810,7 +1803,7 @@ impl Http {
     /// Follow a News Channel to send messages to a target channel.
     pub async fn follow_news_channel<T: DeserializeOwned>(
         &self,
-        news_channel_id: ChannelId,
+        news_channel_id: Snowflake,
         map: &impl Serialize,
     ) -> Result<T> {
         self.fire(Request {
@@ -1893,8 +1886,8 @@ impl Http {
     /// Changes a role in a guild.
     pub async fn edit_role<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
-        role_id: RoleId,
+        guild_id: Snowflake,
+        role_id: Snowflake,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<T> {
@@ -1922,7 +1915,7 @@ impl Http {
     /// Changes the positions of roles in a guild.
     pub async fn edit_role_positions<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
         positions: impl Iterator<Item: Serialize>,
         audit_log_reason: Option<&str>,
     ) -> Result<Vec<T>> {
@@ -1959,8 +1952,8 @@ impl Http {
     /// [Manage Events]: Permissions::MANAGE_EVENTS
     pub async fn edit_scheduled_event<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
-        event_id: ScheduledEventId,
+        guild_id: Snowflake,
+        event_id: Snowflake,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<T> {
@@ -1983,8 +1976,8 @@ impl Http {
     /// See [`GuildId::edit_sticker`] for permissions requirements.
     pub async fn edit_sticker<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
-        sticker_id: StickerId,
+        guild_id: Snowflake,
+        sticker_id: Snowflake,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<T> {
@@ -2012,8 +2005,8 @@ impl Http {
     /// Changes another user's voice state in a stage channel.
     pub async fn edit_voice_state(
         &self,
-        guild_id: GuildId,
-        user_id: UserId,
+        guild_id: Snowflake,
+        user_id: Snowflake,
         map: &impl Serialize,
     ) -> Result<()> {
         self.wind(Request {
@@ -2031,7 +2024,11 @@ impl Http {
     }
 
     /// Changes the current user's voice state in a stage channel.
-    pub async fn edit_voice_state_me(&self, guild_id: GuildId, map: &impl Serialize) -> Result<()> {
+    pub async fn edit_voice_state_me(
+        &self,
+        guild_id: Snowflake,
+        map: &impl Serialize,
+    ) -> Result<()> {
         self.wind(Request {
             body: Some(to_vec(map)?),
             multipart: None,
@@ -2048,7 +2045,7 @@ impl Http {
     /// Changes a voice channel's status.
     pub async fn edit_voice_status(
         &self,
-        channel_id: ChannelId,
+        channel_id: Snowflake,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
@@ -2068,7 +2065,7 @@ impl Http {
     /// Edits a the webhook with the given data.
     pub async fn edit_webhook<T: DeserializeOwned>(
         &self,
-        webhook_id: WebhookId,
+        webhook_id: Snowflake,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<T> {
@@ -2088,7 +2085,7 @@ impl Http {
     /// Edits the webhook with the given data.
     pub async fn edit_webhook_with_token<T: DeserializeOwned>(
         &self,
-        webhook_id: WebhookId,
+        webhook_id: Snowflake,
         token: &str,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
@@ -2110,8 +2107,8 @@ impl Http {
     /// Executes a webhook, posting a [`Message`] in the webhook's associated [`Channel`].
     pub async fn execute_webhook<T: DeserializeOwned>(
         &self,
-        webhook_id: WebhookId,
-        thread_id: Option<ThreadId>,
+        webhook_id: Snowflake,
+        thread_id: Option<Snowflake>,
         token: &str,
         wait: bool,
         files: Vec<AttachmentData<'_>>,
@@ -2128,8 +2125,8 @@ impl Http {
     /// [Discord docs]: https://docs.discord.com/developers/resources/webhook#execute-webhook-query-string-params
     pub async fn execute_webhook_with_components<T: DeserializeOwned>(
         &self,
-        webhook_id: WebhookId,
-        thread_id: Option<ThreadId>,
+        webhook_id: Snowflake,
+        thread_id: Option<Snowflake>,
         token: &str,
         wait: bool,
         files: Vec<AttachmentData<'_>>,
@@ -2141,8 +2138,8 @@ impl Http {
     #[expect(clippy::too_many_arguments)]
     async fn execute_webhook_<T: DeserializeOwned>(
         &self,
-        webhook_id: WebhookId,
-        thread_id: Option<ThreadId>,
+        webhook_id: Snowflake,
+        thread_id: Option<Snowflake>,
         token: &str,
         wait: bool,
         files: Vec<AttachmentData<'_>>,
@@ -2194,10 +2191,10 @@ impl Http {
     // Gets a webhook's message by Id
     pub async fn get_webhook_message<T: DeserializeOwned>(
         &self,
-        webhook_id: WebhookId,
-        thread_id: Option<ThreadId>,
+        webhook_id: Snowflake,
+        thread_id: Option<Snowflake>,
         token: &str,
-        message_id: MessageId,
+        message_id: Snowflake,
     ) -> Result<T> {
         let thread_id_str;
         let mut params = None;
@@ -2225,10 +2222,10 @@ impl Http {
     /// Edits a webhook's message by Id.
     pub async fn edit_webhook_message<T: DeserializeOwned>(
         &self,
-        webhook_id: WebhookId,
-        thread_id: Option<ThreadId>,
+        webhook_id: Snowflake,
+        thread_id: Option<Snowflake>,
         token: &str,
-        message_id: MessageId,
+        message_id: Snowflake,
         map: &impl Serialize,
         new_attachments: Vec<AttachmentData<'_>>,
     ) -> Result<T> {
@@ -2269,10 +2266,10 @@ impl Http {
     /// Deletes a webhook's message by Id.
     pub async fn delete_webhook_message(
         &self,
-        webhook_id: WebhookId,
-        thread_id: Option<ThreadId>,
+        webhook_id: Snowflake,
+        thread_id: Option<Snowflake>,
         token: &str,
-        message_id: MessageId,
+        message_id: Snowflake,
     ) -> Result<()> {
         let thread_id_str;
         let mut params = None;
@@ -2328,12 +2325,10 @@ impl Http {
     ///
     /// If `target` is set, then users will be filtered by Id, such that their Id comes before or
     /// after the provided [`UserId`] wrapped by the [`UserPagination`].
-    ///
-    /// [`UserId`]: crate::model::id::UserId
     pub async fn get_bans<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
-        target: Option<UserPagination>,
+        guild_id: Snowflake,
+        target: Option<Pagination>,
         limit: Option<NonMaxU16>,
     ) -> Result<Vec<T>> {
         let id_str;
@@ -2347,8 +2342,8 @@ impl Http {
 
         if let Some(target) = target {
             let (name, id) = match target {
-                UserPagination::After(id) => ("after", id),
-                UserPagination::Before(id) => ("before", id),
+                Pagination::After(id) => ("after", id),
+                Pagination::Before(id) => ("before", id),
             };
 
             id_str = id.to_arraystring();
@@ -2380,8 +2375,8 @@ impl Http {
     /// [Ban Members]: Permissions::BAN_MEMBERS
     pub async fn get_ban<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
-        user_id: UserId,
+        guild_id: Snowflake,
+        user_id: Snowflake,
     ) -> Result<Option<T>> {
         let result = self
             .fire(Request {
@@ -2409,11 +2404,11 @@ impl Http {
     /// Gets all audit logs in a specific guild.
     pub async fn get_audit_logs<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
         action_type: Option<u16>,
-        user_id: Option<UserId>,
-        before: Option<AuditLogEntryId>,
-        after: Option<AuditLogEntryId>,
+        user_id: Option<Snowflake>,
+        before: Option<Snowflake>,
+        after: Option<Snowflake>,
         limit: Option<NonMaxU8>,
     ) -> Result<T> {
         let (action_type_str, before_str, after_str, limit_str, user_id_str);
@@ -2455,7 +2450,7 @@ impl Http {
     /// Retrieves all auto moderation rules in a guild.
     pub async fn get_automod_rules<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
     ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
@@ -2473,8 +2468,8 @@ impl Http {
     /// Retrieves an auto moderation rule in a guild.
     pub async fn get_automod_rule<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
-        rule_id: RuleId,
+        guild_id: Snowflake,
+        rule_id: Snowflake,
     ) -> Result<T> {
         self.fire(Request {
             body: None,
@@ -2493,7 +2488,7 @@ impl Http {
     /// Creates an auto moderation rule in a guild.
     pub async fn create_automod_rule<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<T> {
@@ -2513,8 +2508,8 @@ impl Http {
     /// Retrieves an auto moderation rule in a guild.
     pub async fn edit_automod_rule<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
-        rule_id: RuleId,
+        guild_id: Snowflake,
+        rule_id: Snowflake,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<T> {
@@ -2535,8 +2530,8 @@ impl Http {
     /// Deletes an auto moderation rule in a guild.
     pub async fn delete_automod_rule(
         &self,
-        guild_id: GuildId,
-        rule_id: RuleId,
+        guild_id: Snowflake,
+        rule_id: Snowflake,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
         self.wind(Request {
@@ -2569,7 +2564,7 @@ impl Http {
     /// Gets all invites for a channel.
     pub async fn get_channel_invites<T: DeserializeOwned>(
         &self,
-        channel_id: ChannelId,
+        channel_id: Snowflake,
     ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
@@ -2587,7 +2582,7 @@ impl Http {
     /// Gets all thread members for a thread.
     pub async fn get_channel_thread_members<T: DeserializeOwned>(
         &self,
-        thread_id: ThreadId,
+        thread_id: Snowflake,
     ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
@@ -2605,7 +2600,7 @@ impl Http {
     /// Gets all active threads from a guild.
     pub async fn get_guild_active_threads<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
     ) -> Result<T> {
         self.fire(Request {
             body: None,
@@ -2623,7 +2618,7 @@ impl Http {
     /// Gets all archived public threads from a channel.
     pub async fn get_channel_archived_public_threads<T: DeserializeOwned>(
         &self,
-        channel_id: ChannelId,
+        channel_id: Snowflake,
         before: Option<Timestamp>,
         limit: Option<u64>,
     ) -> Result<T> {
@@ -2654,7 +2649,7 @@ impl Http {
     /// Gets all archived private threads from a channel.
     pub async fn get_channel_archived_private_threads<T: DeserializeOwned>(
         &self,
-        channel_id: ChannelId,
+        channel_id: Snowflake,
         before: Option<Timestamp>,
         limit: Option<u64>,
     ) -> Result<T> {
@@ -2685,8 +2680,8 @@ impl Http {
     /// Gets all archived private threads joined from a channel.
     pub async fn get_channel_joined_archived_private_threads<T: DeserializeOwned>(
         &self,
-        channel_id: ChannelId,
-        before: Option<ChannelId>,
+        channel_id: Snowflake,
+        before: Option<Snowflake>,
         limit: Option<u64>,
     ) -> Result<T> {
         let (before_str, limit_str);
@@ -2714,7 +2709,7 @@ impl Http {
     }
 
     /// Joins a thread channel.
-    pub async fn join_thread_channel(&self, thread_id: ThreadId) -> Result<()> {
+    pub async fn join_thread_channel(&self, thread_id: Snowflake) -> Result<()> {
         self.wind(Request {
             body: None,
             multipart: None,
@@ -2729,7 +2724,7 @@ impl Http {
     }
 
     /// Leaves a thread channel.
-    pub async fn leave_thread_channel(&self, thread_id: ThreadId) -> Result<()> {
+    pub async fn leave_thread_channel(&self, thread_id: Snowflake) -> Result<()> {
         self.wind(Request {
             body: None,
             multipart: None,
@@ -2746,8 +2741,8 @@ impl Http {
     /// Adds a member to a thread channel.
     pub async fn add_thread_channel_member(
         &self,
-        thread_id: ThreadId,
-        user_id: UserId,
+        thread_id: Snowflake,
+        user_id: Snowflake,
     ) -> Result<()> {
         self.wind(Request {
             body: None,
@@ -2766,8 +2761,8 @@ impl Http {
     /// Removes a member from a thread channel.
     pub async fn remove_thread_channel_member(
         &self,
-        thread_id: ThreadId,
-        user_id: UserId,
+        thread_id: Snowflake,
+        user_id: Snowflake,
     ) -> Result<()> {
         self.wind(Request {
             body: None,
@@ -2785,8 +2780,8 @@ impl Http {
 
     pub async fn get_thread_channel_member<T: DeserializeOwned>(
         &self,
-        thread_id: ThreadId,
-        user_id: UserId,
+        thread_id: Snowflake,
+        user_id: Snowflake,
         with_member: bool,
     ) -> Result<T> {
         self.fire(Request {
@@ -2806,7 +2801,7 @@ impl Http {
     /// Retrieves the webhooks for the given [channel][`GuildChannel`]'s Id.
     pub async fn get_channel_webhooks<T: DeserializeOwned>(
         &self,
-        channel_id: ChannelId,
+        channel_id: Snowflake,
     ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
@@ -2822,10 +2817,7 @@ impl Http {
     }
 
     /// Gets channel information.
-    pub async fn get_channel<T: DeserializeOwned>(
-        &self,
-        channel_id: GenericChannelId,
-    ) -> Result<T> {
+    pub async fn get_channel<T: DeserializeOwned>(&self, channel_id: Snowflake) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2840,10 +2832,11 @@ impl Http {
     }
 
     /// Gets all channels in a guild.
-    pub async fn get_channels<T: DeserializeOwned + ExtractKey<ChannelId>>(
-        &self,
-        guild_id: GuildId,
-    ) -> Result<ExtractMap<ChannelId, T>> {
+    pub async fn get_channels<T, Id>(&self, guild_id: Snowflake) -> Result<ExtractMap<Id, T>>
+    where
+        T: DeserializeOwned + ExtractKey<Id>,
+        Id: Hash + Eq,
+    {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2860,7 +2853,7 @@ impl Http {
     /// Gets a stage instance.
     pub async fn get_stage_instance<T: DeserializeOwned>(
         &self,
-        channel_id: ChannelId,
+        channel_id: Snowflake,
     ) -> Result<T> {
         self.fire(Request {
             body: None,
@@ -2878,10 +2871,10 @@ impl Http {
     /// Get a list of users that voted for this specific answer.
     pub async fn get_poll_answer_voters<T: DeserializeOwned>(
         &self,
-        channel_id: GenericChannelId,
-        message_id: MessageId,
-        answer_id: AnswerId,
-        after: Option<UserId>,
+        channel_id: Snowflake,
+        message_id: Snowflake,
+        answer_id: u8,
+        after: Option<Snowflake>,
         limit: Option<u8>,
     ) -> Result<Vec<T>> {
         let (after_str, limit_str);
@@ -2919,8 +2912,8 @@ impl Http {
 
     pub async fn expire_poll<T: DeserializeOwned>(
         &self,
-        channel_id: GenericChannelId,
-        message_id: MessageId,
+        channel_id: Snowflake,
+        message_id: Snowflake,
     ) -> Result<T> {
         self.fire(Request {
             body: None,
@@ -2965,7 +2958,7 @@ impl Http {
     }
 
     /// Gets all emojis of a guild.
-    pub async fn get_emojis<T: DeserializeOwned>(&self, guild_id: GuildId) -> Result<Vec<T>> {
+    pub async fn get_emojis<T: DeserializeOwned>(&self, guild_id: Snowflake) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -2982,8 +2975,8 @@ impl Http {
     /// Gets information about an emoji in a guild.
     pub async fn get_emoji<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
-        emoji_id: EmojiId,
+        guild_id: Snowflake,
+        emoji_id: Snowflake,
     ) -> Result<T> {
         self.fire(Request {
             body: None,
@@ -3021,7 +3014,10 @@ impl Http {
     }
 
     /// Gets information about an application emoji.
-    pub async fn get_application_emoji<T: DeserializeOwned>(&self, emoji_id: EmojiId) -> Result<T> {
+    pub async fn get_application_emoji<T: DeserializeOwned>(
+        &self,
+        emoji_id: Snowflake,
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3043,7 +3039,7 @@ impl Http {
     /// [`Self::get_entitlements`].
     ///
     /// [`Consumable`]: SkuKind::Consumable
-    pub async fn consume_entitlement(&self, entitlement_id: EntitlementId) -> Result<()> {
+    pub async fn consume_entitlement(&self, entitlement_id: Snowflake) -> Result<()> {
         self.wind(Request {
             body: None,
             multipart: None,
@@ -3062,12 +3058,12 @@ impl Http {
     /// Gets all entitlements for the current app, active and expired.
     pub async fn get_entitlements<T: DeserializeOwned>(
         &self,
-        user_id: Option<UserId>,
-        sku_ids: Option<&[SkuId]>,
-        before: Option<EntitlementId>,
-        after: Option<EntitlementId>,
+        user_id: Option<Snowflake>,
+        sku_ids: Option<&[Snowflake]>,
+        before: Option<Snowflake>,
+        after: Option<Snowflake>,
         limit: Option<NonMaxU8>,
-        guild_id: Option<GuildId>,
+        guild_id: Option<Snowflake>,
         exclude_ended: Option<bool>,
     ) -> Result<Vec<T>> {
         let (user_id_str, sku_ids_str, before_str, after_str, limit_str, guild_id_str, exclude_str);
@@ -3162,7 +3158,7 @@ impl Http {
     /// Fetches a global commands for your application by its Id.
     pub async fn get_global_command<T: DeserializeOwned>(
         &self,
-        command_id: CommandId,
+        command_id: Snowflake,
     ) -> Result<T> {
         self.fire(Request {
             body: None,
@@ -3179,7 +3175,7 @@ impl Http {
     }
 
     /// Gets guild information.
-    pub async fn get_guild<T: DeserializeOwned>(&self, guild_id: GuildId) -> Result<T> {
+    pub async fn get_guild<T: DeserializeOwned>(&self, guild_id: Snowflake) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3194,7 +3190,10 @@ impl Http {
     }
 
     /// Gets guild information with counts.
-    pub async fn get_guild_with_counts<T: DeserializeOwned>(&self, guild_id: GuildId) -> Result<T> {
+    pub async fn get_guild_with_counts<T: DeserializeOwned>(
+        &self,
+        guild_id: Snowflake,
+    ) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3211,7 +3210,7 @@ impl Http {
     /// Fetches all of the guild commands for your application for a specific guild.
     pub async fn get_guild_commands<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
     ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
@@ -3231,7 +3230,7 @@ impl Http {
     /// guild.
     pub async fn get_guild_commands_with_localizations<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
     ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
@@ -3250,8 +3249,8 @@ impl Http {
     /// Fetches a guild command by its Id.
     pub async fn get_guild_command<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
-        command_id: CommandId,
+        guild_id: Snowflake,
+        command_id: Snowflake,
     ) -> Result<T> {
         self.fire(Request {
             body: None,
@@ -3271,7 +3270,7 @@ impl Http {
     /// Fetches all of the guild commands permissions for your application for a specific guild.
     pub async fn get_guild_commands_permissions<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
     ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
@@ -3290,8 +3289,8 @@ impl Http {
     /// Gives the guild command permission for your application for a specific guild.
     pub async fn get_guild_command_permissions<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
-        command_id: CommandId,
+        guild_id: Snowflake,
+        command_id: Snowflake,
     ) -> Result<T> {
         self.fire(Request {
             body: None,
@@ -3309,7 +3308,7 @@ impl Http {
     }
 
     /// Gets a guild widget information.
-    pub async fn get_guild_widget<T: DeserializeOwned>(&self, guild_id: GuildId) -> Result<T> {
+    pub async fn get_guild_widget<T: DeserializeOwned>(&self, guild_id: Snowflake) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3324,7 +3323,7 @@ impl Http {
     }
 
     /// Gets a guild preview.
-    pub async fn get_guild_preview<T: DeserializeOwned>(&self, guild_id: GuildId) -> Result<T> {
+    pub async fn get_guild_preview<T: DeserializeOwned>(&self, guild_id: Snowflake) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -3341,7 +3340,7 @@ impl Http {
     /// Gets a guild welcome screen information.
     pub async fn get_guild_welcome_screen<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
     ) -> Result<T> {
         self.fire(Request {
             body: None,
@@ -3359,7 +3358,7 @@ impl Http {
     /// Gets integrations that a guild has.
     pub async fn get_guild_integrations<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
     ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
@@ -3377,7 +3376,7 @@ impl Http {
     /// Gets all invites to a guild.
     pub async fn get_guild_invites<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
     ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
@@ -3393,7 +3392,10 @@ impl Http {
     }
 
     /// Gets a guild's vanity URL if it has one.
-    pub async fn get_guild_vanity_url<T: DeserializeOwned>(&self, guild_id: GuildId) -> Result<T> {
+    pub async fn get_guild_vanity_url<T: DeserializeOwned>(
+        &self,
+        guild_id: Snowflake,
+    ) -> Result<T> {
         let resp = self
             .fire::<Value>(Request {
                 body: None,
@@ -3417,9 +3419,9 @@ impl Http {
     /// result by.
     pub async fn get_guild_members<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
         limit: Option<NonMaxU16>,
-        after: Option<UserId>,
+        after: Option<Snowflake>,
     ) -> Result<Vec<T>> {
         let (limit_str, after_str);
         let mut params = ArrayVec::<_, 2>::new();
@@ -3459,7 +3461,7 @@ impl Http {
     /// Gets the amount of users that can be pruned.
     pub async fn get_guild_prune_count<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
         days: u8,
     ) -> Result<T> {
         let days_str = days.to_arraystring();
@@ -3480,7 +3482,7 @@ impl Http {
     /// additional VIP-only regions are returned.
     pub async fn get_guild_regions<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
     ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
@@ -3498,8 +3500,8 @@ impl Http {
     /// Retrieves a specific role in a [`Guild`].
     pub async fn get_guild_role<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
-        role_id: RoleId,
+        guild_id: Snowflake,
+        role_id: Snowflake,
     ) -> Result<T> {
         let mut value: Value = self
             .fire(Request {
@@ -3525,8 +3527,8 @@ impl Http {
     /// Retrieves a map of role IDs with total members each. Does not include `everyone` role.
     pub async fn get_guild_role_member_counts(
         &self,
-        guild_id: GuildId,
-    ) -> Result<HashMap<RoleId, u32>> {
+        guild_id: Snowflake,
+    ) -> Result<HashMap<Snowflake, u32>> {
         let value: Value = self
             .fire(Request {
                 body: None,
@@ -3544,10 +3546,11 @@ impl Http {
     }
 
     /// Retrieves a list of roles in a [`Guild`].
-    pub async fn get_guild_roles<T: DeserializeOwned + ExtractKey<RoleId>>(
-        &self,
-        guild_id: GuildId,
-    ) -> Result<ExtractMap<RoleId, T>> {
+    pub async fn get_guild_roles<T, Id>(&self, guild_id: Snowflake) -> Result<ExtractMap<Id, T>>
+    where
+        T: DeserializeOwned + ExtractKey<Id>,
+        Id: Hash + Eq,
+    {
         let mut value: Value = self
             .fire(Request {
                 body: None,
@@ -3575,8 +3578,8 @@ impl Http {
     /// Gets a scheduled event by Id.
     pub async fn get_scheduled_event<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
-        event_id: ScheduledEventId,
+        guild_id: Snowflake,
+        event_id: Snowflake,
         with_user_count: bool,
     ) -> Result<T> {
         let with_user_count_str = with_user_count.to_arraystring();
@@ -3597,7 +3600,7 @@ impl Http {
     /// Gets a list of all scheduled events for the corresponding guild.
     pub async fn get_scheduled_events<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
         with_user_count: bool,
     ) -> Result<Vec<T>> {
         let with_user_count_str = with_user_count.to_arraystring();
@@ -3618,10 +3621,10 @@ impl Http {
     /// options for filtering.
     pub async fn get_scheduled_event_users<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
-        event_id: ScheduledEventId,
+        guild_id: Snowflake,
+        event_id: Snowflake,
         limit: Option<NonMaxU8>,
-        target: Option<UserPagination>,
+        target: Option<Pagination>,
         with_member: Option<bool>,
     ) -> Result<Vec<T>> {
         let (limit_str, with_member_str, id_str);
@@ -3636,8 +3639,8 @@ impl Http {
         }
         if let Some(target) = target {
             let (name, id) = match target {
-                UserPagination::After(id) => ("after", id),
-                UserPagination::Before(id) => ("before", id),
+                Pagination::After(id) => ("after", id),
+                Pagination::Before(id) => ("before", id),
             };
 
             id_str = id.to_arraystring();
@@ -3661,7 +3664,7 @@ impl Http {
     /// Retrieves a list of stickers in a [`Guild`].
     pub async fn get_guild_stickers<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
     ) -> Result<Vec<T>> {
         let mut value: Value = self
             .fire(Request {
@@ -3690,8 +3693,8 @@ impl Http {
     /// Retrieves a single sticker in a [`Guild`].
     pub async fn get_guild_sticker<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
-        sticker_id: StickerId,
+        guild_id: Snowflake,
+        sticker_id: Snowflake,
     ) -> Result<T> {
         let mut value: Value = self
             .fire(Request {
@@ -3717,7 +3720,7 @@ impl Http {
     /// Retrieves the webhooks for the given [`Guild`]'s Id.
     pub async fn get_guild_webhooks<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
     ) -> Result<Vec<T>> {
         self.fire(Request {
             body: None,
@@ -3737,7 +3740,7 @@ impl Http {
     /// The `limit` has a maximum value of 200.
     pub async fn get_guilds<T: DeserializeOwned>(
         &self,
-        target: Option<GuildPagination>,
+        target: Option<Pagination>,
         limit: Option<NonMaxU8>,
     ) -> Result<Vec<T>> {
         let (limit_str, id_str);
@@ -3748,8 +3751,8 @@ impl Http {
         }
         if let Some(target) = target {
             let (name, id) = match target {
-                GuildPagination::After(id) => ("after", id),
-                GuildPagination::Before(id) => ("before", id),
+                Pagination::After(id) => ("after", id),
+                Pagination::Before(id) => ("before", id),
             };
 
             id_str = id.to_arraystring();
@@ -3774,7 +3777,7 @@ impl Http {
     /// [`GuildsMembersRead`]: crate::model::application::Scope::GuildsMembersRead
     pub async fn get_current_user_guild_member<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
     ) -> Result<T> {
         let mut value: Value = self
             .fire(Request {
@@ -3801,7 +3804,7 @@ impl Http {
         &self,
         code: &str,
         member_counts: bool,
-        event_id: Option<ScheduledEventId>,
+        event_id: Option<Snowflake>,
     ) -> Result<T> {
         let (member_counts_str, event_id_str);
         let mut params = ArrayVec::<_, 2>::new();
@@ -3830,8 +3833,8 @@ impl Http {
     /// Gets member of a guild.
     pub async fn get_member<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
-        user_id: UserId,
+        guild_id: Snowflake,
+        user_id: Snowflake,
     ) -> Result<T> {
         let mut value: Value = self
             .fire(Request {
@@ -3857,8 +3860,8 @@ impl Http {
     /// Gets a message by an Id, bots only.
     pub async fn get_message<T: DeserializeOwned>(
         &self,
-        channel_id: GenericChannelId,
-        message_id: MessageId,
+        channel_id: Snowflake,
+        message_id: Snowflake,
     ) -> Result<T> {
         self.fire(Request {
             body: None,
@@ -3877,7 +3880,7 @@ impl Http {
     /// Gets X messages from a channel.
     pub async fn get_messages<T: DeserializeOwned>(
         &self,
-        channel_id: GenericChannelId,
+        channel_id: Snowflake,
         target: Option<MessagePagination>,
         limit: Option<NonMaxU8>,
     ) -> Result<Vec<T>> {
@@ -3916,7 +3919,7 @@ impl Http {
     /// Retrieves a specific [`StickerPack`] from it's [`StickerPackId`]
     pub async fn get_sticker_pack<T: DeserializeOwned>(
         &self,
-        sticker_pack_id: StickerPackId,
+        sticker_pack_id: Snowflake,
     ) -> Result<T> {
         self.fire(Request {
             body: None,
@@ -3953,7 +3956,7 @@ impl Http {
     /// Gets all pins of a channel.
     pub async fn get_pins<T: DeserializeOwned>(
         &self,
-        channel_id: GenericChannelId,
+        channel_id: Snowflake,
         before: Option<Timestamp>,
         limit: Option<u8>,
     ) -> Result<T> {
@@ -3986,12 +3989,12 @@ impl Http {
     /// Gets a list of users who reacted with an emoji.
     pub async fn get_reaction_users<T: DeserializeOwned>(
         &self,
-        channel_id: GenericChannelId,
-        message_id: MessageId,
+        channel_id: Snowflake,
+        message_id: Snowflake,
         emoji: &str,
         reaction_type: Option<ReactionTypes>,
         limit: Option<NonMaxU8>,
-        after: Option<UserId>,
+        after: Option<Snowflake>,
     ) -> Result<Vec<T>> {
         let (type_str, limit_str, after_str);
         let mut params = ArrayVec::<_, 3>::new();
@@ -4042,7 +4045,7 @@ impl Http {
     }
 
     /// Gets a sticker.
-    pub async fn get_sticker<T: DeserializeOwned>(&self, sticker_id: StickerId) -> Result<T> {
+    pub async fn get_sticker<T: DeserializeOwned>(&self, sticker_id: Snowflake) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -4103,7 +4106,7 @@ impl Http {
     }
 
     /// Gets a user by Id.
-    pub async fn get_user<T: DeserializeOwned>(&self, user_id: UserId) -> Result<T> {
+    pub async fn get_user<T: DeserializeOwned>(&self, user_id: Snowflake) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -4164,8 +4167,8 @@ impl Http {
     /// Returns the specified user's voice state in the guild.
     pub async fn get_user_voice_state<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
-        user_id: UserId,
+        guild_id: Snowflake,
+        user_id: Snowflake,
     ) -> Result<T> {
         self.fire(Request {
             body: None,
@@ -4185,7 +4188,7 @@ impl Http {
     ///
     /// This method requires authentication, whereas [`Http::get_webhook_with_token`] and
     /// [`Http::get_webhook_from_url`] do not.
-    pub async fn get_webhook<T: DeserializeOwned>(&self, webhook_id: WebhookId) -> Result<T> {
+    pub async fn get_webhook<T: DeserializeOwned>(&self, webhook_id: Snowflake) -> Result<T> {
         self.fire(Request {
             body: None,
             multipart: None,
@@ -4204,7 +4207,7 @@ impl Http {
     /// This method does _not_ require authentication.
     pub async fn get_webhook_with_token<T: DeserializeOwned>(
         &self,
-        webhook_id: WebhookId,
+        webhook_id: Snowflake,
         token: &str,
     ) -> Result<T> {
         self.fire(Request {
@@ -4246,8 +4249,8 @@ impl Http {
     /// Kicks a member from a guild with a provided reason.
     pub async fn kick_member(
         &self,
-        guild_id: GuildId,
-        user_id: UserId,
+        guild_id: Snowflake,
+        user_id: Snowflake,
         reason: Option<&str>,
     ) -> Result<()> {
         self.wind(Request {
@@ -4265,7 +4268,7 @@ impl Http {
     }
 
     /// Leaves a guild.
-    pub async fn leave_guild(&self, guild_id: GuildId) -> Result<()> {
+    pub async fn leave_guild(&self, guild_id: Snowflake) -> Result<()> {
         self.wind(Request {
             body: None,
             multipart: None,
@@ -4282,7 +4285,7 @@ impl Http {
     /// Sends a message to a channel.
     pub async fn send_message<T: DeserializeOwned>(
         &self,
-        channel_id: GenericChannelId,
+        channel_id: Snowflake,
         files: Vec<AttachmentData<'_>>,
         map: &impl Serialize,
     ) -> Result<T> {
@@ -4313,8 +4316,8 @@ impl Http {
     /// Pins a message in a channel.
     pub async fn pin_message(
         &self,
-        channel_id: GenericChannelId,
-        message_id: MessageId,
+        channel_id: Snowflake,
+        message_id: Snowflake,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
         self.wind(Request {
@@ -4334,8 +4337,8 @@ impl Http {
     /// Unbans a user from a guild.
     pub async fn remove_ban(
         &self,
-        guild_id: GuildId,
-        user_id: UserId,
+        guild_id: Snowflake,
+        user_id: Snowflake,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
         self.wind(Request {
@@ -4355,9 +4358,9 @@ impl Http {
     /// Deletes a single [`Role`] from a [`Member`] in a [`Guild`].
     pub async fn remove_member_role(
         &self,
-        guild_id: GuildId,
-        user_id: UserId,
-        role_id: RoleId,
+        guild_id: Snowflake,
+        user_id: Snowflake,
+        role_id: Snowflake,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
         self.wind(Request {
@@ -4379,7 +4382,7 @@ impl Http {
     /// provided string.
     pub async fn search_guild_members<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
         query: &str,
         limit: Option<NonMaxU16>,
     ) -> Result<Vec<T>> {
@@ -4411,7 +4414,7 @@ impl Http {
     /// Starts removing some members from a guild based on the last time they've been online.
     pub async fn start_guild_prune<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
         days: u8,
         audit_log_reason: Option<&str>,
     ) -> Result<T> {
@@ -4432,8 +4435,8 @@ impl Http {
     /// Starts syncing an integration with a guild.
     pub async fn start_integration_sync(
         &self,
-        guild_id: GuildId,
-        integration_id: IntegrationId,
+        guild_id: Snowflake,
+        integration_id: Snowflake,
     ) -> Result<()> {
         self.wind(Request {
             body: None,
@@ -4456,7 +4459,7 @@ impl Http {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn edit_guild_incident_actions<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
         map: &impl Serialize,
     ) -> Result<T> {
         self.fire(Request {
@@ -4475,8 +4478,8 @@ impl Http {
     /// Unpins a message from a channel.
     pub async fn unpin_message(
         &self,
-        channel_id: GenericChannelId,
-        message_id: MessageId,
+        channel_id: Snowflake,
+        message_id: Snowflake,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
         self.wind(Request {
@@ -4496,7 +4499,7 @@ impl Http {
     /// Sends a soundboard sound to a voice channel the user is connected to.
     pub async fn send_soundboard_sound(
         &self,
-        channel_id: ChannelId,
+        channel_id: Snowflake,
         map: &impl Serialize,
     ) -> Result<()> {
         self.wind(Request {
@@ -4528,7 +4531,7 @@ impl Http {
     /// Retrieves soundboard sounds from a guild.
     pub async fn get_guild_soundboards<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
     ) -> Result<Vec<T>> {
         let result = self
             .fire::<Value>(Request {
@@ -4552,8 +4555,8 @@ impl Http {
     /// Retrieves a soundboard sound from a guild.
     pub async fn get_guild_soundboard<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
-        sound_id: SoundId,
+        guild_id: Snowflake,
+        sound_id: Snowflake,
     ) -> Result<T> {
         self.fire(Request {
             body: None,
@@ -4572,7 +4575,7 @@ impl Http {
     /// Creates a soundboard sound in a guild.
     pub async fn create_guild_soundboard<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
+        guild_id: Snowflake,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<T> {
@@ -4592,8 +4595,8 @@ impl Http {
     /// Edits a soundboard sound in a guild.
     pub async fn edit_guild_soundboard<T: DeserializeOwned>(
         &self,
-        guild_id: GuildId,
-        sound_id: SoundId,
+        guild_id: Snowflake,
+        sound_id: Snowflake,
         map: &impl Serialize,
         audit_log_reason: Option<&str>,
     ) -> Result<T> {
@@ -4614,8 +4617,8 @@ impl Http {
     /// Deletes a soundboard sound in a guild.
     pub async fn delete_guild_soundboard(
         &self,
-        guild_id: GuildId,
-        sound_id: SoundId,
+        guild_id: Snowflake,
+        sound_id: Snowflake,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
         self.wind(Request {

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -67,29 +67,19 @@ impl LightMethod {
     }
 }
 
-/// Representation of the method of a query to send for the [`Http::get_guilds`] function.
+/// Representation of the method of a query to send for the [`Http::get_guilds`],
+/// [`Http::get_bans`], and [`Http::get_scheduled_event_users`], functions.
 #[non_exhaustive]
-pub enum GuildPagination {
-    /// The Id to get the guilds after.
-    After(GuildId),
-    /// The Id to get the guilds before.
-    Before(GuildId),
+pub enum Pagination {
+    After(Snowflake),
+    Before(Snowflake),
 }
 
-/// Representation of the method of a query to send for the [`Http::get_scheduled_event_users`] and
-/// [`Http::get_bans`] functions.
-#[non_exhaustive]
-pub enum UserPagination {
-    /// The Id to get the users after.
-    After(UserId),
-    /// The Id to get the users before.
-    Before(UserId),
-}
-
+/// Representation of the method of a query to send for the [`Http::get_messages`] function.
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 pub enum MessagePagination {
-    After(MessageId),
-    Around(MessageId),
-    Before(MessageId),
+    After(Snowflake),
+    Around(Snowflake),
+    Before(Snowflake),
 }

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -150,7 +150,7 @@ impl Ratelimiter {
     /// # let http: Http = unimplemented!();
     /// let routes = http.ratelimiter.unwrap().routes();
     ///
-    /// let channel_id = GenericChannelId::new(7);
+    /// let channel_id = Snowflake::new(7);
     /// let route = Route::Channel {
     ///     channel_id,
     /// };

--- a/src/http/routing.rs
+++ b/src/http/routing.rs
@@ -1,10 +1,10 @@
 use std::borrow::Cow;
 
-use crate::model::id::*;
+use crate::model::id::Snowflake;
 
 /// Used to group requests together for ratelimiting.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub struct RatelimitingBucket(Option<(RouteKind, Option<GenericId>)>);
+pub struct RatelimitingBucket(Option<(RouteKind, Option<Snowflake>)>);
 
 impl RatelimitingBucket {
     #[must_use]
@@ -16,7 +16,7 @@ impl RatelimitingBucket {
 enum RatelimitingKind {
     /// Requests with the same path and major parameter (usually an Id) should be grouped together
     /// for ratelimiting.
-    PathAndId(GenericId),
+    PathAndId(Snowflake),
     /// Requests with the same path should be ratelimited together.
     Path,
 }
@@ -89,117 +89,117 @@ macro_rules! routes {
 // 2. The second line provides the url for that endpoint.
 // 3. The third line indicates what type of ratelimiting the endpoint employs.
 routes! ('a, {
-    Channel { channel_id: GenericChannelId },
+    Channel { channel_id: Snowflake },
     api!("/channels/{}", channel_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
+    Some(RatelimitingKind::PathAndId(channel_id));
 
-    ChannelInvites { channel_id: ChannelId },
+    ChannelInvites { channel_id: Snowflake },
     api!("/channels/{}/invites", channel_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
+    Some(RatelimitingKind::PathAndId(channel_id));
 
-    ChannelMessage { channel_id: GenericChannelId, message_id: MessageId },
+    ChannelMessage { channel_id: Snowflake, message_id: Snowflake },
     api!("/channels/{}/messages/{}", channel_id, message_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
+    Some(RatelimitingKind::PathAndId(channel_id));
 
-    ChannelMessageCrosspost { channel_id: ChannelId, message_id: MessageId },
+    ChannelMessageCrosspost { channel_id: Snowflake, message_id: Snowflake },
     api!("/channels/{}/messages/{}/crosspost", channel_id, message_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
+    Some(RatelimitingKind::PathAndId(channel_id));
 
-    ChannelMessageReaction { channel_id: GenericChannelId, message_id: MessageId, user_id: UserId, reaction: &'a str },
+    ChannelMessageReaction { channel_id: Snowflake, message_id: Snowflake, user_id: Snowflake, reaction: &'a str },
     api!("/channels/{}/messages/{}/reactions/{}/{}", channel_id, message_id, reaction, user_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
+    Some(RatelimitingKind::PathAndId(channel_id));
 
-    ChannelMessageReactionMe { channel_id: GenericChannelId, message_id: MessageId, reaction: &'a str },
+    ChannelMessageReactionMe { channel_id: Snowflake, message_id: Snowflake, reaction: &'a str },
     api!("/channels/{}/messages/{}/reactions/{}/@me", channel_id, message_id, reaction),
-    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
+    Some(RatelimitingKind::PathAndId(channel_id));
 
-    ChannelMessageReactionEmoji { channel_id: GenericChannelId, message_id: MessageId, reaction: &'a str },
+    ChannelMessageReactionEmoji { channel_id: Snowflake, message_id: Snowflake, reaction: &'a str },
     api!("/channels/{}/messages/{}/reactions/{}", channel_id, message_id, reaction),
-    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
+    Some(RatelimitingKind::PathAndId(channel_id));
 
-    ChannelMessageReactions { channel_id: GenericChannelId, message_id: MessageId },
+    ChannelMessageReactions { channel_id: Snowflake, message_id: Snowflake },
     api!("/channels/{}/messages/{}/reactions", channel_id, message_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
+    Some(RatelimitingKind::PathAndId(channel_id));
 
-    ChannelMessages { channel_id: GenericChannelId },
+    ChannelMessages { channel_id: Snowflake },
     api!("/channels/{}/messages", channel_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
+    Some(RatelimitingKind::PathAndId(channel_id));
 
-    ChannelMessagesBulkDelete { channel_id: GenericChannelId },
+    ChannelMessagesBulkDelete { channel_id: Snowflake },
     api!("/channels/{}/messages/bulk-delete", channel_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
+    Some(RatelimitingKind::PathAndId(channel_id));
 
-    ChannelFollowNews { channel_id: ChannelId },
+    ChannelFollowNews { channel_id: Snowflake },
     api!("/channels/{}/followers", channel_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
+    Some(RatelimitingKind::PathAndId(channel_id));
 
-    ChannelPermission { channel_id: ChannelId, target_id: TargetId },
+    ChannelPermission { channel_id: Snowflake, target_id: Snowflake },
     api!("/channels/{}/permissions/{}", channel_id, target_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
+    Some(RatelimitingKind::PathAndId(channel_id));
 
-    ChannelPin { channel_id: GenericChannelId, message_id: MessageId },
+    ChannelPin { channel_id: Snowflake, message_id: Snowflake },
     api!("/channels/{}/messages/pins/{}", channel_id, message_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
+    Some(RatelimitingKind::PathAndId(channel_id));
 
-    ChannelPins { channel_id: GenericChannelId },
+    ChannelPins { channel_id: Snowflake },
     api!("/channels/{}/messages/pins", channel_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
+    Some(RatelimitingKind::PathAndId(channel_id));
 
-    ChannelTyping { channel_id: GenericChannelId },
+    ChannelTyping { channel_id: Snowflake },
     api!("/channels/{}/typing", channel_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
+    Some(RatelimitingKind::PathAndId(channel_id));
 
-    ChannelWebhooks { channel_id: ChannelId },
+    ChannelWebhooks { channel_id: Snowflake },
     api!("/channels/{}/webhooks", channel_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
+    Some(RatelimitingKind::PathAndId(channel_id));
 
-    ChannelMessageThreads { channel_id: ChannelId, message_id: MessageId },
+    ChannelMessageThreads { channel_id: Snowflake, message_id: Snowflake },
     api!("/channels/{}/messages/{}/threads", channel_id, message_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
+    Some(RatelimitingKind::PathAndId(channel_id));
 
-    ChannelThreads { channel_id: ChannelId },
+    ChannelThreads { channel_id: Snowflake },
     api!("/channels/{}/threads", channel_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
+    Some(RatelimitingKind::PathAndId(channel_id));
 
-    ChannelForumPosts { channel_id: ChannelId },
+    ChannelForumPosts { channel_id: Snowflake },
     api!("/channels/{}/threads", channel_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
+    Some(RatelimitingKind::PathAndId(channel_id));
 
-    ChannelThreadMember { thread_id: ThreadId, user_id: UserId },
+    ChannelThreadMember { thread_id: Snowflake, user_id: Snowflake },
     api!("/channels/{}/thread-members/{}", thread_id, user_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(thread_id.get())));
+    Some(RatelimitingKind::PathAndId(thread_id));
 
-    ChannelThreadMemberMe { thread_id: ThreadId },
+    ChannelThreadMemberMe { thread_id: Snowflake },
     api!("/channels/{}/thread-members/@me", thread_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(thread_id.get())));
+    Some(RatelimitingKind::PathAndId(thread_id));
 
-    ChannelThreadMembers { thread_id: ThreadId },
+    ChannelThreadMembers { thread_id: Snowflake },
     api!("/channels/{}/thread-members", thread_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(thread_id.get())));
+    Some(RatelimitingKind::PathAndId(thread_id));
 
-    ChannelArchivedPublicThreads { channel_id: ChannelId },
+    ChannelArchivedPublicThreads { channel_id: Snowflake },
     api!("/channels/{}/threads/archived/public", channel_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
+    Some(RatelimitingKind::PathAndId(channel_id));
 
-    ChannelArchivedPrivateThreads { channel_id: ChannelId },
+    ChannelArchivedPrivateThreads { channel_id: Snowflake },
     api!("/channels/{}/threads/archived/private", channel_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
+    Some(RatelimitingKind::PathAndId(channel_id));
 
-    ChannelJoinedPrivateThreads { channel_id: ChannelId },
+    ChannelJoinedPrivateThreads { channel_id: Snowflake },
     api!("/channels/{}/users/@me/threads/archived/private", channel_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
+    Some(RatelimitingKind::PathAndId(channel_id));
 
-    ChannelPollGetAnswerVoters { channel_id: GenericChannelId, message_id: MessageId, answer_id: AnswerId },
+    ChannelPollGetAnswerVoters { channel_id: Snowflake, message_id: Snowflake, answer_id: u8 },
     api!("/channels/{}/polls/{}/answers/{}", channel_id, message_id, answer_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
+    Some(RatelimitingKind::PathAndId(channel_id));
 
-    ChannelPollExpire { channel_id: GenericChannelId, message_id: MessageId },
+    ChannelPollExpire { channel_id: Snowflake, message_id: Snowflake },
     api!("/channels/{}/polls/{}/expire", channel_id, message_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
+    Some(RatelimitingKind::PathAndId(channel_id));
 
-    ChannelVoiceStatus { channel_id: ChannelId },
+    ChannelVoiceStatus { channel_id: Snowflake },
     api!("/channels/{}/voice-status", channel_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
+    Some(RatelimitingKind::PathAndId(channel_id));
 
     Gateway,
     api!("/gateway"),
@@ -209,161 +209,161 @@ routes! ('a, {
     api!("/gateway/bot"),
     Some(RatelimitingKind::Path);
 
-    Guild { guild_id: GuildId },
+    Guild { guild_id: Snowflake },
     api!("/guilds/{}", guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildAuditLogs { guild_id: GuildId },
+    GuildAuditLogs { guild_id: Snowflake },
     api!("/guilds/{}/audit-logs", guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildAutomodRule { guild_id: GuildId, rule_id: RuleId },
+    GuildAutomodRule { guild_id: Snowflake, rule_id: Snowflake },
     api!("/guilds/{}/auto-moderation/rules/{}", guild_id, rule_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildAutomodRules { guild_id: GuildId },
+    GuildAutomodRules { guild_id: Snowflake },
     api!("/guilds/{}/auto-moderation/rules", guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildBan { guild_id: GuildId, user_id: UserId },
+    GuildBan { guild_id: Snowflake, user_id: Snowflake },
     api!("/guilds/{}/bans/{}", guild_id, user_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildBulkBan { guild_id: GuildId },
+    GuildBulkBan { guild_id: Snowflake },
     api!("/guilds/{}/bulk-ban", guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildBans { guild_id: GuildId },
+    GuildBans { guild_id: Snowflake },
     api!("/guilds/{}/bans", guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildChannels { guild_id: GuildId },
+    GuildChannels { guild_id: Snowflake },
     api!("/guilds/{}/channels", guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildWidget { guild_id: GuildId },
+    GuildWidget { guild_id: Snowflake },
     api!("/guilds/{}/widget", guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildPreview { guild_id: GuildId },
+    GuildPreview { guild_id: Snowflake },
     api!("/guilds/{}/preview", guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildEmojis { guild_id: GuildId },
+    GuildEmojis { guild_id: Snowflake },
     api!("/guilds/{}/emojis", guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildEmoji { guild_id: GuildId, emoji_id: EmojiId },
+    GuildEmoji { guild_id: Snowflake, emoji_id: Snowflake },
     api!("/guilds/{}/emojis/{}", guild_id, emoji_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildIntegration { guild_id: GuildId, integration_id: IntegrationId },
+    GuildIntegration { guild_id: Snowflake, integration_id: Snowflake },
     api!("/guilds/{}/integrations/{}", guild_id, integration_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildIntegrationSync { guild_id: GuildId, integration_id: IntegrationId },
+    GuildIntegrationSync { guild_id: Snowflake, integration_id: Snowflake },
     api!("/guilds/{}/integrations/{}/sync", guild_id, integration_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildIntegrations { guild_id: GuildId },
+    GuildIntegrations { guild_id: Snowflake },
     api!("/guilds/{}/integrations", guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildInvites { guild_id: GuildId },
+    GuildInvites { guild_id: Snowflake },
     api!("/guilds/{}/invites", guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildMember { guild_id: GuildId, user_id: UserId },
+    GuildMember { guild_id: Snowflake, user_id: Snowflake },
     api!("/guilds/{}/members/{}", guild_id, user_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildMemberRole { guild_id: GuildId, user_id: UserId, role_id: RoleId },
+    GuildMemberRole { guild_id: Snowflake, user_id: Snowflake, role_id: Snowflake },
     api!("/guilds/{}/members/{}/roles/{}", guild_id, user_id, role_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildMembers { guild_id: GuildId },
+    GuildMembers { guild_id: Snowflake },
     api!("/guilds/{}/members", guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildMembersSearch { guild_id: GuildId },
+    GuildMembersSearch { guild_id: Snowflake },
     api!("/guilds/{}/members/search", guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildMemberMe { guild_id: GuildId },
+    GuildMemberMe { guild_id: Snowflake },
     api!("/guilds/{}/members/@me", guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildMfa { guild_id: GuildId },
+    GuildMfa { guild_id: Snowflake },
     api!("/guilds/{}/mfa", guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildPrune { guild_id: GuildId },
+    GuildPrune { guild_id: Snowflake },
     api!("/guilds/{}/prune", guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildRegions { guild_id: GuildId },
+    GuildRegions { guild_id: Snowflake },
     api!("/guilds/{}/regions", guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildRole { guild_id: GuildId, role_id: RoleId },
+    GuildRole { guild_id: Snowflake, role_id: Snowflake },
     api!("/guilds/{}/roles/{}", guild_id, role_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildRoles { guild_id: GuildId },
+    GuildRoles { guild_id: Snowflake },
     api!("/guilds/{}/roles", guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildRoleMemberCounts { guild_id: GuildId },
+    GuildRoleMemberCounts { guild_id: Snowflake },
     api!("/guilds/{}/roles/member-counts", guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildScheduledEvent { guild_id: GuildId, event_id: ScheduledEventId },
+    GuildScheduledEvent { guild_id: Snowflake, event_id: Snowflake },
     api!("/guilds/{}/scheduled-events/{}", guild_id, event_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildScheduledEvents { guild_id: GuildId },
+    GuildScheduledEvents { guild_id: Snowflake },
     api!("/guilds/{}/scheduled-events", guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildScheduledEventUsers { guild_id: GuildId, event_id: ScheduledEventId },
+    GuildScheduledEventUsers { guild_id: Snowflake, event_id: Snowflake },
     api!("/guilds/{}/scheduled-events/{}/users", guild_id, event_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildSticker { guild_id: GuildId, sticker_id: StickerId },
+    GuildSticker { guild_id: Snowflake, sticker_id: Snowflake },
     api!("/guilds/{}/stickers/{}", guild_id, sticker_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildStickers { guild_id: GuildId },
+    GuildStickers { guild_id: Snowflake },
     api!("/guilds/{}/stickers", guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildVanityUrl { guild_id: GuildId },
+    GuildVanityUrl { guild_id: Snowflake },
     api!("/guilds/{}/vanity-url", guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildVoiceStates { guild_id: GuildId, user_id: UserId },
+    GuildVoiceStates { guild_id: Snowflake, user_id: Snowflake },
     api!("/guilds/{}/voice-states/{}", guild_id, user_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildVoiceStateMe { guild_id: GuildId },
+    GuildVoiceStateMe { guild_id: Snowflake },
     api!("/guilds/{}/voice-states/@me", guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildWebhooks { guild_id: GuildId },
+    GuildWebhooks { guild_id: Snowflake },
     api!("/guilds/{}/webhooks", guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildWelcomeScreen { guild_id: GuildId },
+    GuildWelcomeScreen { guild_id: Snowflake },
     api!("/guilds/{}/welcome-screen", guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildThreadsActive { guild_id: GuildId },
+    GuildThreadsActive { guild_id: Snowflake },
     api!("/guilds/{}/threads/active", guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildIncidentActions { guild_id: GuildId },
+    GuildIncidentActions { guild_id: Snowflake },
     api!("/guilds/{}/incident-actions", guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
     Guilds,
     api!("/guilds"),
@@ -389,21 +389,21 @@ routes! ('a, {
     api!("/oauth2/@me"),
     None;
 
-    SoundboardSend { channel_id: ChannelId },
+    SoundboardSend { channel_id: Snowflake },
     api!("/channels/{}/send-soundboard-sound", channel_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(channel_id.get())));
+    Some(RatelimitingKind::PathAndId(channel_id));
 
     SoundboardDefaultSounds,
     api!("/soundboard-default-sounds"),
     Some(RatelimitingKind::Path);
 
-    GuildSoundboards { guild_id: GuildId },
+    GuildSoundboards { guild_id: Snowflake },
     api!("/guilds/{}/soundboard-sounds", guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
-    GuildSoundboard { guild_id: GuildId, sound_id: SoundId },
+    GuildSoundboard { guild_id: Snowflake, sound_id: Snowflake },
     api!("/guilds/{}/soundboard-sounds/{}", guild_id, sound_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(guild_id.get())));
+    Some(RatelimitingKind::PathAndId(guild_id));
 
     StatusIncidentsUnresolved,
     status!("/incidents/unresolved.json"),
@@ -417,7 +417,7 @@ routes! ('a, {
     status!("/scheduled-maintenances/upcoming.json"),
     None;
 
-    Sticker { sticker_id: StickerId },
+    Sticker { sticker_id: Snowflake },
     api!("/stickers/{}", sticker_id),
     Some(RatelimitingKind::Path);
 
@@ -425,11 +425,11 @@ routes! ('a, {
     api!("/sticker-packs"),
     Some(RatelimitingKind::Path);
 
-    StickerPack { sticker_pack_id: StickerPackId },
+    StickerPack { sticker_pack_id: Snowflake },
     api!("/sticker-packs/{}", sticker_pack_id),
     Some(RatelimitingKind::Path);
 
-    User { user_id: UserId },
+    User { user_id: Snowflake },
     api!("/users/{}", user_id),
     Some(RatelimitingKind::Path);
 
@@ -445,11 +445,11 @@ routes! ('a, {
     api!("/users/@me/channels"),
     Some(RatelimitingKind::Path);
 
-    UserMeGuild { guild_id: GuildId },
+    UserMeGuild { guild_id: Snowflake },
     api!("/users/@me/guilds/{}", guild_id),
     Some(RatelimitingKind::Path);
 
-    UserMeGuildMember { guild_id: GuildId },
+    UserMeGuildMember { guild_id: Snowflake },
     api!("/users/@me/guilds/{}/member", guild_id),
     Some(RatelimitingKind::Path);
 
@@ -461,87 +461,87 @@ routes! ('a, {
     api!("/voice/regions"),
     Some(RatelimitingKind::Path);
 
-    Webhook { webhook_id: WebhookId },
+    Webhook { webhook_id: Snowflake },
     api!("/webhooks/{}", webhook_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(webhook_id.get())));
+    Some(RatelimitingKind::PathAndId(webhook_id));
 
-    WebhookWithToken { webhook_id: WebhookId, token: &'a str },
+    WebhookWithToken { webhook_id: Snowflake, token: &'a str },
     api!("/webhooks/{}/{}", webhook_id, token),
-    Some(RatelimitingKind::PathAndId(GenericId::new(webhook_id.get())));
+    Some(RatelimitingKind::PathAndId(webhook_id));
 
-    WebhookMessage { webhook_id: WebhookId, token: &'a str, message_id: MessageId },
+    WebhookMessage { webhook_id: Snowflake, token: &'a str, message_id: Snowflake },
     api!("/webhooks/{}/{}/messages/{}", webhook_id, token, message_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(webhook_id.get())));
+    Some(RatelimitingKind::PathAndId(webhook_id));
 
-    WebhookOriginalInteractionResponse { application_id: ApplicationId, token: &'a str },
+    WebhookOriginalInteractionResponse { application_id: Snowflake, token: &'a str },
     api!("/webhooks/{}/{}/messages/@original", application_id, token),
-    Some(RatelimitingKind::PathAndId(GenericId::new(application_id.get())));
+    Some(RatelimitingKind::PathAndId(application_id));
 
-    WebhookFollowupMessage { application_id: ApplicationId, token: &'a str, message_id: MessageId },
+    WebhookFollowupMessage { application_id: Snowflake, token: &'a str, message_id: Snowflake },
     api!("/webhooks/{}/{}/messages/{}", application_id, token, message_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(application_id.get())));
+    Some(RatelimitingKind::PathAndId(application_id));
 
-    WebhookFollowupMessages { application_id: ApplicationId, token: &'a str },
+    WebhookFollowupMessages { application_id: Snowflake, token: &'a str },
     api!("/webhooks/{}/{}", application_id, token),
-    Some(RatelimitingKind::PathAndId(GenericId::new(application_id.get())));
+    Some(RatelimitingKind::PathAndId(application_id));
 
-    InteractionResponse { interaction_id: InteractionId, token: &'a str },
+    InteractionResponse { interaction_id: Snowflake, token: &'a str },
     api!("/interactions/{}/{}/callback", interaction_id, token),
-    Some(RatelimitingKind::PathAndId(GenericId::new(interaction_id.get())));
+    Some(RatelimitingKind::PathAndId(interaction_id));
 
-    Command { application_id: ApplicationId, command_id: CommandId },
+    Command { application_id: Snowflake, command_id: Snowflake },
     api!("/applications/{}/commands/{}", application_id, command_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(application_id.get())));
+    Some(RatelimitingKind::PathAndId(application_id));
 
-    Commands { application_id: ApplicationId },
+    Commands { application_id: Snowflake },
     api!("/applications/{}/commands", application_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(application_id.get())));
+    Some(RatelimitingKind::PathAndId(application_id));
 
-    GuildCommand { application_id: ApplicationId, guild_id: GuildId, command_id: CommandId },
+    GuildCommand { application_id: Snowflake, guild_id: Snowflake, command_id: Snowflake },
     api!("/applications/{}/guilds/{}/commands/{}", application_id, guild_id, command_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(application_id.get())));
+    Some(RatelimitingKind::PathAndId(application_id));
 
-    GuildCommandPermissions { application_id: ApplicationId, guild_id: GuildId, command_id: CommandId },
+    GuildCommandPermissions { application_id: Snowflake, guild_id: Snowflake, command_id: Snowflake },
     api!("/applications/{}/guilds/{}/commands/{}/permissions", application_id, guild_id, command_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(application_id.get())));
+    Some(RatelimitingKind::PathAndId(application_id));
 
-    GuildCommands { application_id: ApplicationId, guild_id: GuildId },
+    GuildCommands { application_id: Snowflake, guild_id: Snowflake },
     api!("/applications/{}/guilds/{}/commands", application_id, guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(application_id.get())));
+    Some(RatelimitingKind::PathAndId(application_id));
 
-    GuildCommandsPermissions { application_id: ApplicationId, guild_id: GuildId },
+    GuildCommandsPermissions { application_id: Snowflake, guild_id: Snowflake },
     api!("/applications/{}/guilds/{}/commands/permissions", application_id, guild_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(application_id.get())));
+    Some(RatelimitingKind::PathAndId(application_id));
 
-    Skus { application_id: ApplicationId },
+    Skus { application_id: Snowflake },
     api!("/applications/{}/skus", application_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(application_id.get())));
+    Some(RatelimitingKind::PathAndId(application_id));
 
-    Emoji { application_id: ApplicationId, emoji_id: EmojiId },
+    Emoji { application_id: Snowflake, emoji_id: Snowflake },
     api!("/applications/{}/emojis/{}", application_id, emoji_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(application_id.get())));
+    Some(RatelimitingKind::PathAndId(application_id));
 
-    Emojis { application_id: ApplicationId },
+    Emojis { application_id: Snowflake },
     api!("/applications/{}/emojis", application_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(application_id.get())));
+    Some(RatelimitingKind::PathAndId(application_id));
 
-    Entitlement { application_id: ApplicationId, entitlement_id: EntitlementId },
+    Entitlement { application_id: Snowflake, entitlement_id: Snowflake },
     api!("/applications/{}/entitlements/{}", application_id, entitlement_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(application_id.get())));
+    Some(RatelimitingKind::PathAndId(application_id));
 
-    ConsumeEntitlement { application_id: ApplicationId, entitlement_id: EntitlementId },
+    ConsumeEntitlement { application_id: Snowflake, entitlement_id: Snowflake },
     api!("/applications/{}/entitlements/{}/consume", application_id, entitlement_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(application_id.get())));
+    Some(RatelimitingKind::PathAndId(application_id));
 
-    Entitlements { application_id: ApplicationId },
+    Entitlements { application_id: Snowflake },
     api!("/applications/{}/entitlements", application_id),
-    Some(RatelimitingKind::PathAndId(GenericId::new(application_id.get())));
+    Some(RatelimitingKind::PathAndId(application_id));
 
     StageInstances,
     api!("/stage-instances"),
     Some(RatelimitingKind::Path);
 
-    StageInstance { channel_id: ChannelId },
+    StageInstance { channel_id: Snowflake },
     api!("/stage-instances/{}", channel_id),
     Some(RatelimitingKind::Path);
 });

--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -197,7 +197,7 @@ impl Command {
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
     pub async fn get_global_command(http: &Http, command_id: CommandId) -> Result<Command> {
-        http.get_global_command(command_id).await
+        http.get_global_command(command_id.0).await
     }
 
     /// Deletes a global command by its Id.
@@ -206,7 +206,7 @@ impl Command {
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
     pub async fn delete_global_command(http: &Http, command_id: CommandId) -> Result<()> {
-        http.delete_global_command(command_id).await
+        http.delete_global_command(command_id.0).await
     }
 }
 

--- a/src/model/application/command_interaction.rs
+++ b/src/model/application/command_interaction.rs
@@ -165,7 +165,7 @@ impl CommandInteraction {
     /// May return [`Error::Http`] if the API returns an error. Such as if the response was already
     /// deleted.
     pub async fn delete_followup(&self, http: &Http, message_id: MessageId) -> Result<()> {
-        http.delete_followup_message(&self.token, message_id).await
+        http.delete_followup_message(&self.token, message_id.0).await
     }
 
     /// Gets a followup message.
@@ -175,7 +175,7 @@ impl CommandInteraction {
     /// May return [`Error::Http`] if the API returns an error. Such as if the response was
     /// deleted.
     pub async fn get_followup(&self, http: &Http, message_id: MessageId) -> Result<Message> {
-        http.get_followup_message(&self.token, message_id).await
+        http.get_followup_message(&self.token, message_id.0).await
     }
 
     /// Helper function to defer an interaction.

--- a/src/model/application/component_interaction.rs
+++ b/src/model/application/component_interaction.rs
@@ -164,7 +164,7 @@ impl ComponentInteraction {
     /// May return [`Error::Http`] if the API returns an error. Such as if the response was already
     /// deleted.
     pub async fn delete_followup(&self, http: &Http, message_id: MessageId) -> Result<()> {
-        http.delete_followup_message(&self.token, message_id).await
+        http.delete_followup_message(&self.token, message_id.0).await
     }
 
     /// Gets a followup message.
@@ -174,7 +174,7 @@ impl ComponentInteraction {
     /// May return [`Error::Http`] if the API returns an error. Such as if the response was
     /// deleted.
     pub async fn get_followup(&self, http: &Http, message_id: MessageId) -> Result<Message> {
-        http.get_followup_message(&self.token, message_id).await
+        http.get_followup_message(&self.token, message_id.0).await
     }
 
     /// Helper function to defer an interaction.

--- a/src/model/application/modal_interaction.rs
+++ b/src/model/application/modal_interaction.rs
@@ -163,7 +163,7 @@ impl ModalInteraction {
     /// May return [`Error::Http`] if the API returns an error. Such as if the response was already
     /// deleted.
     pub async fn delete_followup(&self, http: &Http, message_id: MessageId) -> Result<()> {
-        http.delete_followup_message(&self.token, message_id).await
+        http.delete_followup_message(&self.token, message_id.0).await
     }
 
     /// Helper function to defer an interaction.

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -75,7 +75,7 @@ impl ChannelId {
             }
         }
 
-        let channel = cache_http.http().get_channel(self.widen()).await?;
+        let channel: Channel = cache_http.http().get_channel(self.widen()).await?;
         let guild_channel = channel.guild().ok_or(ModelError::InvalidChannelType)?;
 
         #[cfg(all(feature = "cache", feature = "temp_cache"))]
@@ -722,7 +722,7 @@ impl GenericChannelId {
             return Ok(message.clone());
         }
 
-        let message = cache_http.http().get_message(self, message_id).await?;
+        let message: Message = cache_http.http().get_message(self, message_id).await?;
 
         #[cfg(feature = "temp_cache")]
         if let Some(cache) = cache_http.cache() {
@@ -821,7 +821,7 @@ impl GenericChannelId {
         before: Option<Timestamp>,
         limit: Option<u8>,
     ) -> Result<MessagePinsPage> {
-        let page = cache_http.http().get_pins(self, before, limit).await?;
+        let page: MessagePinsPage = cache_http.http().get_pins(self, before, limit).await?;
 
         #[cfg(feature = "cache")]
         if let Some(cache) = cache_http.cache() {

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -75,7 +75,7 @@ impl ChannelId {
             }
         }
 
-        let channel: Channel = cache_http.http().get_channel(self.widen()).await?;
+        let channel: Channel = cache_http.http().get_channel(self.0).await?;
         let guild_channel = channel.guild().ok_or(ModelError::InvalidChannelType)?;
 
         #[cfg(all(feature = "cache", feature = "temp_cache"))]
@@ -123,7 +123,7 @@ impl ChannelId {
         reason: Option<&str>,
     ) -> Result<()> {
         let data: PermissionOverwriteData = target.into();
-        http.create_permission(self, data.id, &data, reason).await
+        http.create_permission(self.0, data.id.0, &data, reason).await
     }
 
     /// Deletes all permission overrides in the channel from a member or role.
@@ -142,10 +142,10 @@ impl ChannelId {
         reason: Option<&str>,
     ) -> Result<()> {
         let id = match permission_type {
-            PermissionOverwriteType::Member(id) => id.into(),
-            PermissionOverwriteType::Role(id) => id.get().into(),
+            PermissionOverwriteType::Member(id) => id.0,
+            PermissionOverwriteType::Role(id) => id.0,
         };
-        http.delete_permission(self, id, reason).await
+        http.delete_permission(self.0, id, reason).await
     }
 
     /// Edits a channel's settings.
@@ -205,7 +205,7 @@ impl ChannelId {
             webhook_channel_id: target_channel_id,
         };
 
-        http.follow_news_channel(self, &map).await
+        http.follow_news_channel(self.0, &map).await
     }
 
     /// Gets all of the channel's invites.
@@ -218,7 +218,7 @@ impl ChannelId {
     ///
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     pub async fn invites(self, http: &Http) -> Result<Vec<Invite>> {
-        http.get_channel_invites(self).await
+        http.get_channel_invites(self.0).await
     }
 
     /// Crossposts a [`Message`].
@@ -235,7 +235,7 @@ impl ChannelId {
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
     pub async fn crosspost(self, http: &Http, message_id: MessageId) -> Result<Message> {
-        http.crosspost_message(self, message_id).await
+        http.crosspost_message(self.0, message_id.0).await
     }
 
     /// Retrieves the channel's webhooks.
@@ -248,7 +248,7 @@ impl ChannelId {
     ///
     /// [Manage Webhooks]: Permissions::MANAGE_WEBHOOKS
     pub async fn webhooks(self, http: &Http) -> Result<Vec<Webhook>> {
-        http.get_channel_webhooks(self).await
+        http.get_channel_webhooks(self.0).await
     }
 
     /// Creates a webhook in the channel.
@@ -267,7 +267,7 @@ impl ChannelId {
     /// Returns [`Error::Http`] if the channel is not a stage channel, or if there is no stage
     /// instance currently.
     pub async fn get_stage_instance(self, http: &Http) -> Result<StageInstance> {
-        http.get_stage_instance(self).await
+        http.get_stage_instance(self.0).await
     }
 
     /// Creates a stage instance.
@@ -306,7 +306,7 @@ impl ChannelId {
     /// Returns [`Error::Http`] if the channel is not a stage channel, or if there is no stage
     /// instance currently.
     pub async fn delete_stage_instance(self, http: &Http, reason: Option<&str>) -> Result<()> {
-        http.delete_stage_instance(self, reason).await
+        http.delete_stage_instance(self.0, reason).await
     }
 
     /// Creates a public thread that is connected to a message.
@@ -362,7 +362,7 @@ impl ChannelId {
         before: Option<Timestamp>,
         limit: Option<u64>,
     ) -> Result<ThreadsData> {
-        http.get_channel_archived_private_threads(self, before, limit).await
+        http.get_channel_archived_private_threads(self.0, before, limit).await
     }
 
     /// Gets public archived threads of a channel.
@@ -376,7 +376,7 @@ impl ChannelId {
         before: Option<Timestamp>,
         limit: Option<u64>,
     ) -> Result<ThreadsData> {
-        http.get_channel_archived_public_threads(self, before, limit).await
+        http.get_channel_archived_public_threads(self.0, before, limit).await
     }
 
     /// Gets private archived threads joined by the current user of a channel.
@@ -390,7 +390,7 @@ impl ChannelId {
         before: Option<ChannelId>,
         limit: Option<u64>,
     ) -> Result<ThreadsData> {
-        http.get_channel_joined_archived_private_threads(self, before, limit).await
+        http.get_channel_joined_archived_private_threads(self.0, before.map(|id| id.0), limit).await
     }
 
     /// Sends a soundboard sound to this voice channel.
@@ -421,7 +421,7 @@ impl ChannelId {
             source_guild_id: guild_id,
         };
 
-        http.as_ref().send_soundboard_sound(self, &map).await
+        http.as_ref().send_soundboard_sound(self.0, &map).await
     }
 }
 
@@ -455,7 +455,7 @@ impl GenericChannelId {
     ///
     /// [Send Messages]: Permissions::SEND_MESSAGES
     pub async fn broadcast_typing(self, http: &Http) -> Result<()> {
-        http.broadcast_typing(self).await
+        http.broadcast_typing(self.0).await
     }
 
     /// React to a [`Message`] with a custom [`Emoji`] or unicode character.
@@ -476,7 +476,7 @@ impl GenericChannelId {
         message_id: MessageId,
         reaction_type: impl Into<ReactionType>,
     ) -> Result<()> {
-        http.create_reaction(self, message_id, &reaction_type.into().as_data()).await
+        http.create_reaction(self.0, message_id.0, &reaction_type.into().as_data()).await
     }
 
     /// Deletes this channel, returning the channel on a successful deletion.
@@ -489,7 +489,7 @@ impl GenericChannelId {
     ///
     /// [Manage Channels]: Permissions::MANAGE_CHANNELS
     pub async fn delete(self, http: &Http, reason: Option<&str>) -> Result<Channel> {
-        http.delete_channel(self, reason).await
+        http.delete_channel(self.0, reason).await
     }
 
     /// Deletes a [`Message`] given its Id.
@@ -510,7 +510,7 @@ impl GenericChannelId {
         message_id: MessageId,
         reason: Option<&str>,
     ) -> Result<()> {
-        http.delete_message(self, message_id, reason).await
+        http.delete_message(self.0, message_id.0, reason).await
     }
 
     /// Deletes messages by Ids from the given vector in the given channel.
@@ -553,7 +553,7 @@ impl GenericChannelId {
                 messages: message_ids,
             };
 
-            http.delete_messages(self, &req, reason).await
+            http.delete_messages(self.0, &req, reason).await
         }
     }
 
@@ -578,9 +578,10 @@ impl GenericChannelId {
         let reaction_type = reaction_type.into();
         match user_id {
             Some(user_id) => {
-                http.delete_reaction(self, message_id, user_id, &reaction_type.as_data()).await
+                http.delete_reaction(self.0, message_id.0, user_id.0, &reaction_type.as_data())
+                    .await
             },
-            None => http.delete_reaction_me(self, message_id, &reaction_type.as_data()).await,
+            None => http.delete_reaction_me(self.0, message_id.0, &reaction_type.as_data()).await,
         }
     }
     /// Deletes all of the [`Reaction`]s associated with the provided message id.
@@ -595,7 +596,7 @@ impl GenericChannelId {
     ///
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
     pub async fn delete_reactions(self, http: &Http, message_id: MessageId) -> Result<()> {
-        http.delete_message_reactions(self, message_id).await
+        http.delete_message_reactions(self.0, message_id.0).await
     }
 
     /// Deletes all [`Reaction`]s of the given emoji to a message within the channel.
@@ -613,7 +614,8 @@ impl GenericChannelId {
         message_id: MessageId,
         reaction_type: impl Into<ReactionType>,
     ) -> Result<()> {
-        http.delete_message_reaction_emoji(self, message_id, &reaction_type.into().as_data()).await
+        http.delete_message_reaction_emoji(self.0, message_id.0, &reaction_type.into().as_data())
+            .await
     }
 
     /// Edits a [`Message`] in the channel given its Id.
@@ -677,7 +679,7 @@ impl GenericChannelId {
             }
         }
 
-        let channel = cache_http.http().get_channel(self).await?;
+        let channel = cache_http.http().get_channel(self.0).await?;
 
         #[cfg(all(feature = "cache", feature = "temp_cache"))]
         if let Some(cache) = cache_http.cache() {
@@ -722,7 +724,7 @@ impl GenericChannelId {
             return Ok(message.clone());
         }
 
-        let message: Message = cache_http.http().get_message(self, message_id).await?;
+        let message: Message = cache_http.http().get_message(self.0, message_id.0).await?;
 
         #[cfg(feature = "temp_cache")]
         if let Some(cache) = cache_http.cache() {
@@ -799,7 +801,7 @@ impl GenericChannelId {
     ///
     /// [Pin Messages]: Permissions::PIN_MESSAGES
     pub async fn pin(self, http: &Http, message_id: MessageId, reason: Option<&str>) -> Result<()> {
-        http.pin_message(self, message_id, reason).await
+        http.pin_message(self.0, message_id.0, reason).await
     }
 
     /// Gets the list of [`Message`]s which are pinned to the channel.
@@ -821,7 +823,7 @@ impl GenericChannelId {
         before: Option<Timestamp>,
         limit: Option<u8>,
     ) -> Result<MessagePinsPage> {
-        let page: MessagePinsPage = cache_http.http().get_pins(self, before, limit).await?;
+        let page: MessagePinsPage = cache_http.http().get_pins(self.0, before, limit).await?;
 
         #[cfg(feature = "cache")]
         if let Some(cache) = cache_http.cache() {
@@ -864,12 +866,12 @@ impl GenericChannelId {
         after: Option<UserId>,
     ) -> Result<Vec<User>> {
         http.get_reaction_users(
-            self,
-            message_id,
+            self.0,
+            message_id.0,
             &emoji.into().as_data(),
             reaction_type,
             limit,
-            after,
+            after.map(|id| id.0),
         )
         .await
     }
@@ -1032,7 +1034,7 @@ impl GenericChannelId {
         message_id: MessageId,
         reason: Option<&str>,
     ) -> Result<()> {
-        http.unpin_message(self, message_id, reason).await
+        http.unpin_message(self.0, message_id.0, reason).await
     }
 
     /// Get a list of users that voted for this specific answer.
@@ -1048,7 +1050,14 @@ impl GenericChannelId {
         after: Option<UserId>,
         limit: Option<u8>,
     ) -> Result<Vec<User>> {
-        http.get_poll_answer_voters(self, message_id, answer_id, after, limit).await
+        http.get_poll_answer_voters(
+            self.0,
+            message_id.0,
+            answer_id.get(),
+            after.map(|id| id.0),
+            limit,
+        )
+        .await
     }
 
     /// Ends the [`Poll`] on a given [`MessageId`], if there is one.
@@ -1057,7 +1066,7 @@ impl GenericChannelId {
     ///
     /// If the message does not have a poll, or if the poll was not created by the current user.
     pub async fn end_poll(self, http: &Http, message_id: MessageId) -> Result<Message> {
-        http.expire_poll(self, message_id).await
+        http.expire_poll(self.0, message_id.0).await
     }
 }
 

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -592,7 +592,7 @@ impl Message {
             }
         }
 
-        let current_user = cache_http.http().get_current_user().await?;
+        let current_user: CurrentUser = cache_http.http().get_current_user().await?;
         Ok(self.mentions_user_id(current_user.id))
     }
 
@@ -642,7 +642,8 @@ impl Message {
             return channel.parent_id;
         }
 
-        cache_http.http().get_channel(self.channel_id).await.ok()?.guild()?.parent_id
+        let channel: Channel = cache_http.http().get_channel(self.channel_id).await.ok()?;
+        channel.guild()?.parent_id
     }
 }
 

--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -350,8 +350,8 @@ impl Message {
         reaction_type: impl Into<ReactionType>,
     ) -> Result<()> {
         http.delete_message_reaction_emoji(
-            self.channel_id,
-            self.id,
+            self.channel_id.0,
+            self.id.0,
             &reaction_type.into().as_data(),
         )
         .await
@@ -521,7 +521,7 @@ impl Message {
     ///
     /// [Add Reactions]: Permissions::ADD_REACTIONS
     pub async fn react(&self, http: &Http, reaction_type: impl Into<ReactionType>) -> Result<()> {
-        http.create_reaction(self.channel_id, self.id, &reaction_type.into().as_data()).await
+        http.create_reaction(self.channel_id.0, self.id.0, &reaction_type.into().as_data()).await
     }
 
     /// Uses Discord's inline reply to a user without pinging them.
@@ -606,7 +606,7 @@ impl Message {
     ///
     /// [Pin Messages]: Permissions::PIN_MESSAGES
     pub async fn unpin(&self, http: &Http, reason: Option<&str>) -> Result<()> {
-        http.unpin_message(self.channel_id, self.id, reason).await
+        http.unpin_message(self.channel_id.0, self.id.0, reason).await
     }
 
     /// Ends the [`Poll`] on this message, if there is one.
@@ -642,7 +642,7 @@ impl Message {
             return channel.parent_id;
         }
 
-        let channel: Channel = cache_http.http().get_channel(self.channel_id).await.ok()?;
+        let channel: Channel = cache_http.http().get_channel(self.channel_id.0).await.ok()?;
         channel.guild()?.parent_id
     }
 }

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -174,7 +174,8 @@ impl Reaction {
                 }
             }
 
-            Ok(cache_http.http().get_current_user().await?.into())
+            let current_user: CurrentUser = cache_http.http().get_current_user().await?;
+            Ok(current_user.into())
         }
     }
 

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -134,8 +134,12 @@ impl Reaction {
     /// [Manage Messages]: Permissions::MANAGE_MESSAGES
     /// [permissions]: crate::model::permissions
     pub async fn delete_all(&self, http: &Http) -> Result<()> {
-        http.delete_message_reaction_emoji(self.channel_id, self.message_id, &self.emoji.as_data())
-            .await
+        http.delete_message_reaction_emoji(
+            self.channel_id.0,
+            self.message_id.0,
+            &self.emoji.as_data(),
+        )
+        .await
     }
 
     /// Retrieves the [`Message`] associated with this reaction.
@@ -204,12 +208,12 @@ impl Reaction {
         after: Option<UserId>,
     ) -> Result<Vec<User>> {
         http.get_reaction_users(
-            self.channel_id,
-            self.message_id,
+            self.channel_id.0,
+            self.message_id.0,
             &self.emoji.as_data(),
             Some(self.reaction_type),
             limit,
-            after,
+            after.map(|id| id.0),
         )
         .await
     }

--- a/src/model/channel/thread.rs
+++ b/src/model/channel/thread.rs
@@ -51,7 +51,7 @@ impl ThreadId {
             }
         }
 
-        let channel = cache_http.http().get_channel(self.widen()).await?;
+        let channel: Channel = cache_http.http().get_channel(self.widen()).await?;
         let guild_thread = channel.thread().ok_or(ModelError::InvalidChannelType)?;
 
         #[cfg(all(feature = "cache", feature = "temp_cache"))]

--- a/src/model/channel/thread.rs
+++ b/src/model/channel/thread.rs
@@ -51,7 +51,7 @@ impl ThreadId {
             }
         }
 
-        let channel: Channel = cache_http.http().get_channel(self.widen()).await?;
+        let channel: Channel = cache_http.http().get_channel(self.0).await?;
         let guild_thread = channel.thread().ok_or(ModelError::InvalidChannelType)?;
 
         #[cfg(all(feature = "cache", feature = "temp_cache"))]
@@ -75,7 +75,7 @@ impl ThreadId {
     ///
     /// It may return an [`Error::Http`] if the channel is not a thread channel
     pub async fn get_thread_members(self, http: &Http) -> Result<Vec<ThreadMember>> {
-        http.get_channel_thread_members(self).await
+        http.get_channel_thread_members(self.0).await
     }
 
     /// Joins the thread, if this channel is a thread.
@@ -84,7 +84,7 @@ impl ThreadId {
     ///
     /// It may return an [`Error::Http`] if the channel is not a thread channel
     pub async fn join_thread(self, http: &Http) -> Result<()> {
-        http.join_thread_channel(self).await
+        http.join_thread_channel(self.0).await
     }
 
     /// Edits the thread.
@@ -102,7 +102,7 @@ impl ThreadId {
     ///
     /// It may return an [`Error::Http`] if the channel is not a thread channel
     pub async fn leave_thread(self, http: &Http) -> Result<()> {
-        http.leave_thread_channel(self).await
+        http.leave_thread_channel(self.0).await
     }
 
     /// Adds a thread member, if this channel is a thread.
@@ -111,7 +111,7 @@ impl ThreadId {
     ///
     /// It may return an [`Error::Http`] if the channel is not a thread channel
     pub async fn add_thread_member(self, http: &Http, user_id: UserId) -> Result<()> {
-        http.add_thread_channel_member(self, user_id).await
+        http.add_thread_channel_member(self.0, user_id.0).await
     }
 
     /// Removes a thread member, if this channel is a thread.
@@ -120,7 +120,7 @@ impl ThreadId {
     ///
     /// It may return an [`Error::Http`] if the channel is not a thread channel
     pub async fn remove_thread_member(self, http: &Http, user_id: UserId) -> Result<()> {
-        http.remove_thread_channel_member(self, user_id).await
+        http.remove_thread_channel_member(self.0, user_id.0).await
     }
 
     /// Gets a thread member, if this channel is a thread.
@@ -136,7 +136,7 @@ impl ThreadId {
         user_id: UserId,
         with_member: bool,
     ) -> Result<ThreadMember> {
-        http.get_thread_channel_member(self, user_id, with_member).await
+        http.get_thread_channel_member(self.0, user_id.0, with_member).await
     }
 }
 

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -31,7 +31,7 @@ use crate::builder::{
 #[cfg(all(feature = "cache", feature = "model"))]
 use crate::cache::{Cache, GuildRef};
 #[cfg(feature = "model")]
-use crate::http::{Http, UserPagination};
+use crate::http::Http;
 #[cfg(feature = "model")]
 use crate::model::error::Maximum;
 use crate::model::prelude::*;
@@ -48,7 +48,7 @@ impl GuildId {
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn automod_rules(self, http: &Http) -> Result<Vec<AutoModRule>> {
-        http.get_automod_rules(self).await
+        http.get_automod_rules(self.0).await
     }
 
     /// Gets an [`AutoModRule`] of this guild by its ID via HTTP.
@@ -61,7 +61,7 @@ impl GuildId {
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn automod_rule(self, http: &Http, rule_id: RuleId) -> Result<AutoModRule> {
-        http.get_automod_rule(self, rule_id).await
+        http.get_automod_rule(self.0, rule_id.0).await
     }
 
     /// Creates an [`AutoModRule`] in the guild.
@@ -146,7 +146,7 @@ impl GuildId {
         rule_id: RuleId,
         reason: Option<&str>,
     ) -> Result<()> {
-        http.delete_automod_rule(self, rule_id, reason).await
+        http.delete_automod_rule(self.0, rule_id.0, reason).await
     }
 
     /// Adds a [`User`] to this guild with a valid OAuth2 access token.
@@ -203,7 +203,7 @@ impl GuildId {
         dms: u32,
         reason: Option<&str>,
     ) -> Result<()> {
-        http.ban_user(self, user, dms, reason).await
+        http.ban_user(self.0, user.0, dms, reason).await
     }
 
     /// Bans multiple users from the guild, returning the users that were and weren't banned, and
@@ -234,7 +234,7 @@ impl GuildId {
             delete_message_seconds,
         };
 
-        http.bulk_ban_users(self, &map, reason).await
+        http.bulk_ban_users(self.0, &map, reason).await
     }
 
     /// Gets a list of the guild's bans, with additional options and filtering. See
@@ -253,7 +253,7 @@ impl GuildId {
         target: Option<UserPagination>,
         limit: Option<NonMaxU16>,
     ) -> Result<Vec<Ban>> {
-        http.get_bans(self, target, limit).await
+        http.get_bans(self.0, target.map(Into::into), limit).await
     }
 
     /// Gets a user's ban from the guild.
@@ -268,7 +268,7 @@ impl GuildId {
     /// [Ban Members]: Permissions::BAN_MEMBERS
     #[inline]
     pub async fn get_ban(self, http: &Http, user_id: UserId) -> Result<Option<Ban>> {
-        http.get_ban(self, user_id).await
+        http.get_ban(self.0, user_id.0).await
     }
 
     /// Gets a list of the guild's audit log entries
@@ -291,11 +291,11 @@ impl GuildId {
         limit: Option<NonMaxU8>,
     ) -> Result<AuditLogs> {
         http.get_audit_logs(
-            self,
+            self.0,
             action_type.map(audit_log::Action::num),
-            user_id,
-            before,
-            after,
+            user_id.map(|id| id.0),
+            before.map(|id| id.0),
+            after.map(|id| id.0),
             limit,
         )
         .await
@@ -307,7 +307,7 @@ impl GuildId {
     ///
     /// Returns [`Error::Http`] if the current user is not in the guild.
     pub async fn channels(self, http: &Http) -> Result<ExtractMap<ChannelId, GuildChannel>> {
-        http.get_channels(self).await
+        http.get_channels(self.0).await
     }
 
     /// Creates a [`GuildChannel`] in the the guild.
@@ -392,7 +392,7 @@ impl GuildId {
             roles,
         };
 
-        http.create_emoji(self, &body, reason).await
+        http.create_emoji(self.0, &body, reason).await
     }
 
     /// Creates an integration for the guild.
@@ -423,7 +423,7 @@ impl GuildId {
             kind,
         };
 
-        http.create_guild_integration(self, integration_id, &body, reason).await
+        http.create_guild_integration(self.0, integration_id.0, &body, reason).await
     }
 
     /// Creates a new role in the guild with the data set, if any.
@@ -482,7 +482,7 @@ impl GuildId {
     ///
     /// Returns [`Error::Http`] if the current user is not the owner of the guild.
     pub async fn delete(self, http: &Http) -> Result<()> {
-        http.delete_guild(self).await
+        http.delete_guild(self.0).await
     }
 
     /// Deletes an [`Emoji`] from the guild.
@@ -504,7 +504,7 @@ impl GuildId {
         emoji_id: EmojiId,
         reason: Option<&str>,
     ) -> Result<()> {
-        http.delete_emoji(self, emoji_id, reason).await
+        http.delete_emoji(self.0, emoji_id.0, reason).await
     }
 
     /// Deletes an integration by Id from the guild.
@@ -523,7 +523,7 @@ impl GuildId {
         integration_id: IntegrationId,
         reason: Option<&str>,
     ) -> Result<()> {
-        http.delete_guild_integration(self, integration_id, reason).await
+        http.delete_guild_integration(self.0, integration_id.0, reason).await
     }
 
     /// Deletes a [`Role`] by Id from the guild.
@@ -544,7 +544,7 @@ impl GuildId {
         role_id: RoleId,
         reason: Option<&str>,
     ) -> Result<()> {
-        http.delete_role(self, role_id, reason).await
+        http.delete_role(self.0, role_id.0, reason).await
     }
 
     /// Deletes a specified scheduled event in the guild.
@@ -563,7 +563,7 @@ impl GuildId {
         http: &Http,
         event_id: ScheduledEventId,
     ) -> Result<()> {
-        http.delete_scheduled_event(self, event_id).await
+        http.delete_scheduled_event(self.0, event_id.0).await
     }
 
     /// Deletes a [`Sticker`] by id from the guild.
@@ -585,7 +585,7 @@ impl GuildId {
         sticker_id: StickerId,
         reason: Option<&str>,
     ) -> Result<()> {
-        http.delete_sticker(self, sticker_id, reason).await
+        http.delete_sticker(self.0, sticker_id.0, reason).await
     }
 
     /// Edits the current guild with new data where specified.
@@ -637,7 +637,7 @@ impl GuildId {
             roles,
         };
 
-        http.edit_emoji(self, emoji_id, &map, reason).await
+        http.edit_emoji(self.0, emoji_id.0, &map, reason).await
     }
 
     /// Edits the properties a guild member, such as muting or nicknaming them. Returns the new
@@ -703,7 +703,7 @@ impl GuildId {
             level: mfa_level,
         };
 
-        http.edit_guild_mfa_level(self, &map, reason).await
+        http.edit_guild_mfa_level(self.0, &map, reason).await
     }
 
     /// Edits the properties of the bot's member.
@@ -870,7 +870,7 @@ impl GuildId {
             position,
         });
 
-        http.edit_role_positions(self, iter, reason).await
+        http.edit_role_positions(self.0, iter, reason).await
     }
 
     /// Edits the guild's welcome screen.
@@ -914,7 +914,7 @@ impl GuildId {
     /// Returns [`Error::Http`] if the current user is not in the guild, or if the role does not
     /// exist.
     pub async fn role(self, http: &Http, role_id: RoleId) -> Result<Role> {
-        http.get_guild_role(self, role_id).await
+        http.get_guild_role(self.0, role_id.0).await
     }
 
     /// Gets all of the guild's roles over the REST API.
@@ -924,7 +924,7 @@ impl GuildId {
     /// Returns [`Error::Http`] if the current user is not in
     /// the guild.
     pub async fn roles(self, http: &Http) -> Result<ExtractMap<RoleId, Role>> {
-        http.get_guild_roles(self).await
+        http.get_guild_roles(self.0).await
     }
 
     /// Gets the default permission role (@everyone) from the guild.
@@ -957,7 +957,7 @@ impl GuildId {
             }
         }
 
-        cache_http.http().get_guild(self).await
+        cache_http.http().get_guild(self.0).await
     }
 
     /// Requests [`PartialGuild`] over REST API with counts.
@@ -969,7 +969,7 @@ impl GuildId {
     ///
     /// Returns an [`Error::Http`] if the current user is not in the guild.
     pub async fn to_partial_guild_with_counts(self, http: &Http) -> Result<PartialGuild> {
-        http.get_guild_with_counts(self).await
+        http.get_guild_with_counts(self.0).await
     }
 
     /// Gets all [`Emoji`]s of this guild via HTTP.
@@ -978,7 +978,7 @@ impl GuildId {
     ///
     /// Returns an [`Error::Http`] if the guild is unavailable.
     pub async fn emojis(self, http: &Http) -> Result<Vec<Emoji>> {
-        http.get_emojis(self).await
+        http.get_emojis(self.0).await
     }
 
     /// Gets an [`Emoji`] of this guild by its ID via HTTP.
@@ -987,7 +987,7 @@ impl GuildId {
     ///
     /// Returns an [`Error::Http`] if an emoji with that id does not exist.
     pub async fn emoji(self, http: &Http, emoji_id: EmojiId) -> Result<Emoji> {
-        http.get_emoji(self, emoji_id).await
+        http.get_emoji(self.0, emoji_id.0).await
     }
 
     /// Gets all [`Sticker`]s of this guild via HTTP.
@@ -996,7 +996,7 @@ impl GuildId {
     ///
     /// Returns an [`Error::Http`] if the guild is unavailable.
     pub async fn stickers(self, http: &Http) -> Result<Vec<Sticker>> {
-        http.get_guild_stickers(self).await
+        http.get_guild_stickers(self.0).await
     }
 
     /// Gets an [`Sticker`] of this guild by its ID via HTTP.
@@ -1005,7 +1005,7 @@ impl GuildId {
     ///
     /// Returns an [`Error::Http`] if an sticker with that Id does not exist.
     pub async fn sticker(self, http: &Http, sticker_id: StickerId) -> Result<Sticker> {
-        http.get_guild_sticker(self, sticker_id).await
+        http.get_guild_sticker(self.0, sticker_id.0).await
     }
 
     /// Gets all integration of the guild.
@@ -1019,7 +1019,7 @@ impl GuildId {
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn integrations(self, http: &Http) -> Result<Vec<Integration>> {
-        http.get_guild_integrations(self).await
+        http.get_guild_integrations(self.0).await
     }
 
     /// Gets all of the guild's invites.
@@ -1035,7 +1035,7 @@ impl GuildId {
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     /// [View Audit Log]: Permissions::VIEW_AUDIT_LOG
     pub async fn invites(self, http: &Http) -> Result<Vec<Invite>> {
-        http.get_guild_invites(self).await
+        http.get_guild_invites(self.0).await
     }
 
     /// Kicks a [`Member`] from the guild.
@@ -1052,7 +1052,7 @@ impl GuildId {
             Maximum::AuditLogReason.check_overflow(reason.len())?;
         }
 
-        http.kick_member(self, user_id, reason).await
+        http.kick_member(self.0, user_id.0, reason).await
     }
 
     /// Returns a guild [`Member`] object for the current user.
@@ -1064,7 +1064,7 @@ impl GuildId {
     /// Returns an [`Error::Http`] if the current user is not in the guild or the access token
     /// lacks the necessary scope.
     pub async fn current_user_member(self, http: &Http) -> Result<Member> {
-        http.get_current_user_guild_member(self).await
+        http.get_current_user_guild_member(self.0).await
     }
 
     /// Leaves the guild.
@@ -1074,7 +1074,7 @@ impl GuildId {
     /// May return an [`Error::Http`] if the current user cannot leave the guild, or currently is
     /// not in the guild.
     pub async fn leave(self, http: &Http) -> Result<()> {
-        http.leave_guild(self).await
+        http.leave_guild(self.0).await
     }
 
     /// Gets a user's [`Member`] for the guild by Id.
@@ -1097,7 +1097,7 @@ impl GuildId {
             }
         }
 
-        cache_http.http().get_member(self, user_id).await
+        cache_http.http().get_member(self.0, user_id.0).await
     }
 
     /// Gets a list of the guild's members.
@@ -1119,7 +1119,7 @@ impl GuildId {
         limit: Option<NonMaxU16>,
         after: Option<UserId>,
     ) -> Result<Vec<Member>> {
-        http.get_guild_members(self, limit, after).await
+        http.get_guild_members(self.0, limit, after.map(|id| id.0)).await
     }
 
     /// Streams over all the members in a guild.
@@ -1157,7 +1157,7 @@ impl GuildId {
     ///
     /// Returns [`Error::Http`] if the user is not in a voice channel in this guild.
     pub async fn get_user_voice_state(self, http: &Http, user_id: UserId) -> Result<VoiceState> {
-        http.get_user_voice_state(self, user_id).await
+        http.get_user_voice_state(self.0, user_id.0).await
     }
 
     /// Moves a member to a specific voice channel.
@@ -1211,7 +1211,7 @@ impl GuildId {
     ///
     /// [Kick Members]: Permissions::KICK_MEMBERS
     pub async fn prune_count(self, http: &Http, days: u8) -> Result<GuildPrune> {
-        http.get_guild_prune_count(self, days).await
+        http.get_guild_prune_count(self.0, days).await
     }
 
     /// Re-orders the channels of the guild.
@@ -1244,7 +1244,7 @@ impl GuildId {
             position,
         });
 
-        http.edit_guild_channel_positions(self, iter).await
+        http.edit_guild_channel_positions(self.0, iter).await
     }
 
     /// Returns a list of [`Member`]s in a [`Guild`] whose username or nickname starts with a
@@ -1262,7 +1262,7 @@ impl GuildId {
         query: &str,
         limit: Option<NonMaxU16>,
     ) -> Result<Vec<Member>> {
-        http.search_guild_members(self, query, limit).await
+        http.search_guild_members(self.0, query, limit).await
     }
 
     /// Fetches a specified scheduled event in the guild, by Id. If `with_user_count` is set to
@@ -1283,7 +1283,7 @@ impl GuildId {
         event_id: ScheduledEventId,
         with_user_count: bool,
     ) -> Result<ScheduledEvent> {
-        http.get_scheduled_event(self, event_id, with_user_count).await
+        http.get_scheduled_event(self.0, event_id.0, with_user_count).await
     }
 
     /// Fetches a list of all scheduled events in the guild. If `with_user_count` is set to `true`,
@@ -1301,7 +1301,7 @@ impl GuildId {
         http: &Http,
         with_user_count: bool,
     ) -> Result<Vec<ScheduledEvent>> {
-        http.get_scheduled_events(self, with_user_count).await
+        http.get_scheduled_events(self.0, with_user_count).await
     }
 
     /// Fetches a list of interested users for the specified event.
@@ -1322,7 +1322,7 @@ impl GuildId {
         event_id: ScheduledEventId,
         limit: Option<NonMaxU8>,
     ) -> Result<Vec<ScheduledEventUser>> {
-        http.get_scheduled_event_users(self, event_id, limit, None, None).await
+        http.get_scheduled_event_users(self.0, event_id.0, limit, None, None).await
     }
 
     /// Fetches a list of interested users for the specified event, with additional options and
@@ -1344,7 +1344,14 @@ impl GuildId {
         target: Option<UserPagination>,
         with_member: Option<bool>,
     ) -> Result<Vec<ScheduledEventUser>> {
-        http.get_scheduled_event_users(self, event_id, limit, target, with_member).await
+        http.get_scheduled_event_users(
+            self.0,
+            event_id.0,
+            limit,
+            target.map(Into::into),
+            with_member,
+        )
+        .await
     }
 
     /// Returns the Id of the shard associated with the guild.
@@ -1374,7 +1381,7 @@ impl GuildId {
         http: &Http,
         integration_id: IntegrationId,
     ) -> Result<()> {
-        http.start_integration_sync(self, integration_id).await
+        http.start_integration_sync(self.0, integration_id.0).await
     }
 
     /// Starts a prune of [`Member`]s.
@@ -1395,7 +1402,7 @@ impl GuildId {
         days: u8,
         reason: Option<&str>,
     ) -> Result<GuildPrune> {
-        http.start_guild_prune(self, days, reason).await
+        http.start_guild_prune(self.0, days, reason).await
     }
 
     /// Unbans a [`User`] from the guild.
@@ -1408,7 +1415,7 @@ impl GuildId {
     ///
     /// [Ban Members]: Permissions::BAN_MEMBERS
     pub async fn unban(self, http: &Http, user_id: UserId, reason: Option<&str>) -> Result<()> {
-        http.remove_ban(self, user_id, reason).await
+        http.remove_ban(self.0, user_id.0, reason).await
     }
 
     /// Retrieve's the guild's vanity URL.
@@ -1422,7 +1429,7 @@ impl GuildId {
     ///
     /// [Manage Guild]: Permissions::MANAGE_GUILD
     pub async fn vanity_url(self, http: &Http) -> Result<String> {
-        http.get_guild_vanity_url(self).await
+        http.get_guild_vanity_url(self.0).await
     }
 
     /// Retrieves the guild's webhooks.
@@ -1436,7 +1443,7 @@ impl GuildId {
     /// Will return an [`Error::Http`] if the bot is lacking permissions. Can also return an
     /// [`Error::Json`] if there is an error deserializing the API response.
     pub async fn webhooks(self, http: &Http) -> Result<Vec<Webhook>> {
-        http.get_guild_webhooks(self).await
+        http.get_guild_webhooks(self.0).await
     }
 
     /// Create a guild specific application [`Command`].
@@ -1460,7 +1467,7 @@ impl GuildId {
         http: &Http,
         commands: &[CreateCommand<'_>],
     ) -> Result<Vec<Command>> {
-        http.create_guild_commands(self, &commands).await
+        http.create_guild_commands(self.0, &commands).await
     }
 
     /// Overwrites permissions for a specific command.
@@ -1485,7 +1492,7 @@ impl GuildId {
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
     pub async fn get_commands(self, http: &Http) -> Result<Vec<Command>> {
-        http.get_guild_commands(self).await
+        http.get_guild_commands(self.0).await
     }
 
     /// Get all guild application commands with localizations.
@@ -1494,7 +1501,7 @@ impl GuildId {
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
     pub async fn get_commands_with_localizations(self, http: &Http) -> Result<Vec<Command>> {
-        http.get_guild_commands_with_localizations(self).await
+        http.get_guild_commands_with_localizations(self.0).await
     }
 
     /// Get a specific guild application command by its Id.
@@ -1503,7 +1510,7 @@ impl GuildId {
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
     pub async fn get_command(self, http: &Http, command_id: CommandId) -> Result<Command> {
-        http.get_guild_command(self, command_id).await
+        http.get_guild_command(self.0, command_id.0).await
     }
 
     /// Edit a guild application command, given its Id.
@@ -1526,7 +1533,7 @@ impl GuildId {
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
     pub async fn delete_command(self, http: &Http, command_id: CommandId) -> Result<()> {
-        http.delete_guild_command(self, command_id).await
+        http.delete_guild_command(self.0, command_id.0).await
     }
 
     /// Get all guild application commands permissions only.
@@ -1535,7 +1542,7 @@ impl GuildId {
     ///
     /// If there is an error, it will be either [`Error::Http`] or [`Error::Json`].
     pub async fn get_commands_permissions(self, http: &Http) -> Result<Vec<CommandPermissions>> {
-        http.get_guild_commands_permissions(self).await
+        http.get_guild_commands_permissions(self.0).await
     }
 
     /// Get permissions for specific guild application command by its Id.
@@ -1548,7 +1555,7 @@ impl GuildId {
         http: &Http,
         command_id: CommandId,
     ) -> Result<CommandPermissions> {
-        http.get_guild_command_permissions(self, command_id).await
+        http.get_guild_command_permissions(self.0, command_id.0).await
     }
 
     /// Get the guild welcome screen.
@@ -1557,7 +1564,7 @@ impl GuildId {
     ///
     /// Returns [`Error::Http`] if the guild does not have a welcome screen.
     pub async fn get_welcome_screen(self, http: &Http) -> Result<GuildWelcomeScreen> {
-        http.get_guild_welcome_screen(self).await
+        http.get_guild_welcome_screen(self.0).await
     }
 
     /// Get the guild preview.
@@ -1569,7 +1576,7 @@ impl GuildId {
     ///
     /// Returns [`Error::Http`] if the bot cannot see the guild preview, see the note.
     pub async fn get_preview(self, http: &Http) -> Result<GuildPreview> {
-        http.get_guild_preview(self).await
+        http.get_guild_preview(self.0).await
     }
 
     /// Get the guild widget.
@@ -1578,7 +1585,7 @@ impl GuildId {
     ///
     /// Returns [`Error::Http`] if the bot does not have `MANAGE_MESSAGES` permission.
     pub async fn get_widget(self, http: &Http) -> Result<GuildWidget> {
-        http.get_guild_widget(self).await
+        http.get_guild_widget(self.0).await
     }
 
     /// Get the widget image URL.
@@ -1594,7 +1601,7 @@ impl GuildId {
     /// Returns [`Error::Http`] if there is an error in the deserialization, or if the bot issuing
     /// the request is not in the guild.
     pub async fn get_active_threads(self, http: &Http) -> Result<ThreadsData> {
-        http.get_guild_active_threads(self).await
+        http.get_guild_active_threads(self.0).await
     }
 
     /// Gets a soundboard sound from the guild.
@@ -1604,7 +1611,7 @@ impl GuildId {
     /// Returns [`Error::Http`] if there is an error in the deserialization, or if the bot issuing
     /// the request is not in the guild.
     pub async fn get_soundboard(self, http: &Http, sound_id: SoundId) -> Result<Soundboard> {
-        http.get_guild_soundboard(self, sound_id).await
+        http.get_guild_soundboard(self.0, sound_id.0).await
     }
 
     /// Gets all soundboard sounds from the guild.
@@ -1614,7 +1621,7 @@ impl GuildId {
     /// Returns [`Error::Http`] if there is an error in the deserialization, or if the bot issuing
     /// the request is not in the guild.
     pub async fn get_soundboards(self, http: &Http) -> Result<Vec<Soundboard>> {
-        http.get_guild_soundboards(self).await
+        http.get_guild_soundboards(self.0).await
     }
 
     /// Creates a soundboard sound for the guild.
@@ -1656,7 +1663,7 @@ impl GuildId {
         sound_id: SoundId,
         audit_log_reason: Option<&str>,
     ) -> Result<()> {
-        http.delete_guild_soundboard(self, sound_id, audit_log_reason).await
+        http.delete_guild_soundboard(self.0, sound_id.0, audit_log_reason).await
     }
 
     /// Edits the guild incident actions

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -119,7 +119,7 @@ impl Member {
     ///
     /// [Manage Roles]: Permissions::MANAGE_ROLES
     pub async fn add_role(&self, http: &Http, role_id: RoleId, reason: Option<&str>) -> Result<()> {
-        http.add_member_role(self.guild_id, self.user.id, role_id, reason).await
+        http.add_member_role(self.guild_id.0, self.user.id.0, role_id.0, reason).await
     }
 
     /// Adds one or multiple [`Role`]s to the member.
@@ -352,7 +352,7 @@ impl Member {
         role_id: RoleId,
         reason: Option<&str>,
     ) -> Result<()> {
-        http.remove_member_role(self.guild_id, self.user.id, role_id, reason).await
+        http.remove_member_role(self.guild_id.0, self.user.id.0, role_id.0, reason).await
     }
 
     /// Removes one or multiple [`Role`]s from the member.
@@ -406,7 +406,7 @@ impl Member {
     ///
     /// [Ban Members]: Permissions::BAN_MEMBERS
     pub async fn unban(&self, http: &Http, reason: Option<&str>) -> Result<()> {
-        http.remove_ban(self.guild_id, self.user.id, reason).await
+        http.remove_ban(self.guild_id.0, self.user.id.0, reason).await
     }
 
     /// Returns the formatted URL of the member's per guild avatar, if one exists.

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -37,7 +37,7 @@ use crate::builder::EditGuild;
 #[cfg(doc)]
 use crate::constants::LARGE_THRESHOLD;
 #[cfg(feature = "model")]
-use crate::http::Http;
+use crate::http::{Http, Pagination};
 use crate::model::prelude::*;
 #[cfg(feature = "model")]
 use crate::model::utils::*;
@@ -75,6 +75,25 @@ pub struct AfkMetadata {
     /// The amount of seconds a user can not show any activity in a voice channel before being
     /// moved to an AFK channel -- if one exists.
     pub afk_timeout: AfkTimeout,
+}
+
+/// Representation of the method of a query to send for the [`Http::get_guilds`] function.
+#[non_exhaustive]
+pub enum GuildPagination {
+    /// The Id to get the guilds after.
+    After(GuildId),
+    /// The Id to get the guilds before.
+    Before(GuildId),
+}
+
+#[cfg(feature = "model")]
+impl From<GuildPagination> for Pagination {
+    fn from(pagination: GuildPagination) -> Self {
+        match pagination {
+            GuildPagination::After(id) => Pagination::After(id.0),
+            GuildPagination::Before(id) => Pagination::Before(id.0),
+        }
+    }
 }
 
 // A type to standarize the maximum integer size for member counts.
@@ -546,7 +565,7 @@ impl Guild {
         if let Some(member) = self.members.get(&user_id) {
             Ok(Cow::Borrowed(member))
         } else {
-            http.get_member(self.id, user_id).await.map(Cow::Owned)
+            http.get_member(self.id.0, user_id.0).await.map(Cow::Owned)
         }
     }
 

--- a/src/model/id.rs
+++ b/src/model/id.rs
@@ -2,6 +2,7 @@
 #![expect(clippy::unsafe_derive_deserialize)] // This is from `ref_cast`
 
 use std::fmt;
+use std::str::FromStr;
 
 use nonmax::NonMaxU64;
 use serde::de::Error;
@@ -11,22 +12,25 @@ use super::prelude::*;
 use super::timestamp::TimestampOutOfRange;
 
 macro_rules! newtype_display_impl {
-    ($name:ident, |$this:ident| $inner:expr) => {
+    ($name:ident) => {
         impl fmt::Display for $name {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                fmt::Display::fmt(&(|$this: $name| $inner)(*self), f)
+                { self.0 }.fmt(f)
             }
         }
     };
 }
 
-macro_rules! forward_fromstr_impl {
-    ($name:ident, $wrapper:path) => {
-        impl std::str::FromStr for $name {
+macro_rules! newtype_fromstr_impl {
+    ($name:ident) => {
+        impl FromStr for $name {
             type Err = ParseIdError;
 
             fn from_str(s: &str) -> Result<Self, Self::Err> {
-                s.parse().map($wrapper).map(Self).map_err(ParseIdError)
+                match s.parse() {
+                    Ok(id) => Ok(Self(id)),
+                    Err(e) => Err(ParseIdError(e)),
+                }
             }
         }
     };
@@ -49,7 +53,7 @@ macro_rules! id_u64 {
             #[derive(ref_cast::RefCastCustom)]
             #[repr(transparent)]
             #[doc = $doc]
-            pub struct $name(pub(crate) InnerId);
+            pub struct $name(pub(crate) Snowflake);
 
             impl $name {
                 #[doc = concat!("Creates a new ", stringify!($name), " from a u64.")]
@@ -58,15 +62,12 @@ macro_rules! id_u64 {
                 #[must_use]
                 #[track_caller]
                 pub const fn new(id: u64) -> Self {
-                    match NonMaxU64::new(id) {
-                        Some(inner) => Self(InnerId(inner)),
-                        None => panic!(concat!("Attempted to call ", stringify!($name), "::new with invalid (u64::MAX) value"))
-                    }
+                    Self(Snowflake::new(id))
                 }
 
                 #[ref_cast::ref_cast_custom]
                 #[allow(unused, clippy::allow_attributes, reason = "Most IDs don't need casting like this")]
-                pub(crate) const fn cast_from(inner: &InnerId) -> &Self;
+                pub(crate) const fn cast_from(inner: &Snowflake) -> &Self;
 
                 /// Retrieves the inner `id` as a [`u64`].
                 #[must_use]
@@ -74,13 +75,13 @@ macro_rules! id_u64 {
                     // By wrapping `self.0.0` in a block, it forces a Copy, as NonMax::get takes &self.
                     // If removed, the compiler will auto-ref to `&self.0`, which is a
                     // reference to a packed field and therefore errors.
-                    {self.0.0}.get()
+                    self.0.get()
                 }
 
                 #[doc = concat!("Retrieves the time that the ", stringify!($name), " was created.")]
                 #[must_use]
                 pub fn created_at(&self) -> Timestamp {
-                    Timestamp::from_discord_id(self.get())
+                    Timestamp::from_snowflake(self.0)
                 }
             }
 
@@ -123,15 +124,22 @@ macro_rules! id_u64 {
                 }
             }
 
-            newtype_display_impl!($name, |this| this.0.0);
-            forward_fromstr_impl!($name, InnerId);
+            impl From<$name> for Snowflake {
+                fn from(id: $name) -> Snowflake {
+                    id.0
+                }
+            }
+
+            newtype_display_impl!($name);
+
+            newtype_fromstr_impl!($name);
 
             impl ToArrayString for $name {
-                type ArrayString = <u64 as ToArrayString>::ArrayString;
-                const MAX_LENGTH: usize = <u64 as ToArrayString>::MAX_LENGTH;
+                type ArrayString = <Snowflake as ToArrayString>::ArrayString;
+                const MAX_LENGTH: usize = <Snowflake as ToArrayString>::MAX_LENGTH;
 
                 fn to_arraystring(self) -> Self::ArrayString {
-                    self.get().to_arraystring()
+                    self.0.to_arraystring()
                 }
             }
 
@@ -142,7 +150,7 @@ macro_rules! id_u64 {
                 type Error = TimestampOutOfRange;
 
                 fn try_from(value: Timestamp) -> Result<Self, Self::Error> {
-                    Ok(value.try_as_discord_id()?.into())
+                    value.try_as_snowflake().map(Self)
                 }
             }
 
@@ -153,19 +161,59 @@ macro_rules! id_u64 {
 /// The inner storage of an ID.
 #[derive(Clone, Copy, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[repr(Rust, packed)]
-pub(crate) struct InnerId(NonMaxU64);
+#[must_use]
+pub struct Snowflake(NonMaxU64);
 
-impl fmt::Debug for InnerId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let inner = self.0;
-        inner.fmt(f)
+impl Snowflake {
+    pub const fn new(id: u64) -> Self {
+        let Some(inner) = NonMaxU64::new(id) else {
+            panic!("Attempted to call Snowflake::new with invalid (u64::MAX) value")
+        };
+
+        Self(inner)
+    }
+
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        { self.0 }.get()
     }
 }
+
+impl fmt::Debug for Snowflake {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        { self.0 }.fmt(f)
+    }
+}
+
+impl FromStr for Snowflake {
+    type Err = nonmax::ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse().map(Self)
+    }
+}
+
+impl PartialEq<u64> for Snowflake {
+    fn eq(&self, u: &u64) -> bool {
+        self.get() == *u
+    }
+}
+
+impl ToArrayString for Snowflake {
+    type ArrayString = <u64 as ToArrayString>::ArrayString;
+    const MAX_LENGTH: usize = <u64 as ToArrayString>::MAX_LENGTH;
+
+    fn to_arraystring(self) -> Self::ArrayString {
+        self.get().to_arraystring()
+    }
+}
+
+newtype_display_impl!(Snowflake);
 
 struct SnowflakeVisitor;
 
 impl serde::de::Visitor<'_> for SnowflakeVisitor {
-    type Value = InnerId;
+    type Value = Snowflake;
 
     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("a string or integer snowflake that is not u64::MAX")
@@ -178,22 +226,22 @@ impl serde::de::Visitor<'_> for SnowflakeVisitor {
 
     fn visit_u64<E: Error>(self, value: u64) -> Result<Self::Value, E> {
         NonMaxU64::new(value)
-            .map(InnerId)
+            .map(Snowflake)
             .ok_or_else(|| Error::custom("invalid value, expected non-max"))
     }
 
     fn visit_str<E: Error>(self, value: &str) -> Result<Self::Value, E> {
-        value.parse().map(InnerId).map_err(Error::custom)
+        value.parse().map(Snowflake).map_err(Error::custom)
     }
 }
 
-impl<'de> serde::Deserialize<'de> for InnerId {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<InnerId, D::Error> {
+impl<'de> serde::Deserialize<'de> for Snowflake {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Snowflake, D::Error> {
         deserializer.deserialize_any(SnowflakeVisitor)
     }
 }
 
-impl serde::Serialize for InnerId {
+impl serde::Serialize for Snowflake {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.collect_str(&{ self.0 })
     }
@@ -247,7 +295,7 @@ impl ShardId {
     }
 }
 
-newtype_display_impl!(ShardId, |this| this.0);
+newtype_display_impl!(ShardId);
 
 /// An identifier for a [`Poll Answer`](super::channel::PollAnswer).
 ///
@@ -257,26 +305,32 @@ newtype_display_impl!(ShardId, |this| this.0);
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
 #[repr(Rust, packed)]
-pub struct AnswerId(nonmax::NonMaxU8);
+pub struct AnswerId(pub(crate) nonmax::NonMaxU8);
 
 impl AnswerId {
-    /// Retrieves the value as a [`u64`].
+    /// Retrieves the value as a [`u8`].
     ///
     /// Keep in mind that this is **not a snowflake** and the values are subject to change.
     #[must_use]
-    pub fn get(self) -> u64 {
-        { self.0 }.get().into()
+    pub fn get(self) -> u8 {
+        { self.0 }.get()
     }
 }
 
-newtype_display_impl!(AnswerId, |this| this.0);
-forward_fromstr_impl!(AnswerId, std::convert::identity);
+impl fmt::Display for AnswerId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let inner = self.0;
+        inner.fmt(f)
+    }
+}
+
+newtype_fromstr_impl!(AnswerId);
 
 #[cfg(test)]
 mod tests {
     use nonmax::NonMaxU64;
 
-    use super::{GuildId, InnerId};
+    use super::{GuildId, Snowflake};
 
     #[test]
     fn test_created_at() {
@@ -295,7 +349,7 @@ mod tests {
 
         #[derive(Debug, PartialEq, Deserialize, Serialize)]
         struct S {
-            id: InnerId,
+            id: Snowflake,
         }
 
         #[derive(Debug, PartialEq, Deserialize, Serialize)]
@@ -307,7 +361,7 @@ mod tests {
         assert_json(&id, json!("175928847299117063"));
 
         let s = S {
-            id: InnerId(NonMaxU64::new(17_5928_8472_9911_7063).unwrap()),
+            id: Snowflake(NonMaxU64::new(17_5928_8472_9911_7063).unwrap()),
         };
         assert_json(&s, json!({"id": "175928847299117063"}));
 

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -140,7 +140,7 @@ impl Invite {
         member_counts: bool,
         event_id: Option<ScheduledEventId>,
     ) -> Result<Invite> {
-        http.get_invite(code, member_counts, event_id).await
+        http.get_invite(code, member_counts, event_id.map(|id| id.0)).await
     }
 
     /// Returns a URL to use for the invite.

--- a/src/model/monetization.rs
+++ b/src/model/monetization.rs
@@ -126,7 +126,7 @@ impl Entitlement {
     /// [`consumed`]: Entitlement::consumed
     #[cfg(feature = "model")]
     pub async fn consume(&mut self, http: &Http) -> Result<()> {
-        http.consume_entitlement(self.id).await?;
+        http.consume_entitlement(self.id.0).await?;
         self.consumed = Some(true);
         Ok(())
     }

--- a/src/model/sticker.rs
+++ b/src/model/sticker.rs
@@ -14,7 +14,7 @@ impl StickerPackId {
     /// Returns [`Error::Http`] if a [`StickerPack`] with that [`StickerPackId`] does not exist, or
     /// is otherwise unavailable.
     pub async fn to_sticker_pack(self, http: &Http) -> Result<StickerPack> {
-        http.get_sticker_pack(self).await
+        http.get_sticker_pack(self.0).await
     }
 }
 
@@ -27,7 +27,7 @@ impl StickerId {
     /// Returns [`Error::Http`] if a [`Sticker`] with that [`StickerId`] does not exist, or is
     /// otherwise unavailable.
     pub async fn to_sticker(self, http: &Http) -> Result<Sticker> {
-        http.get_sticker(self).await
+        http.get_sticker(self.0).await
     }
 }
 

--- a/src/model/timestamp.rs
+++ b/src/model/timestamp.rs
@@ -42,6 +42,8 @@ pub use time::error::Parse as InnerError;
 #[cfg(not(feature = "chrono"))]
 use time::{Duration, OffsetDateTime, format_description::well_known::Rfc3339, serde::rfc3339};
 
+use crate::model::id::Snowflake;
+
 /// Discord's epoch starts at "2015-01-01T00:00:00+00:00"
 const DISCORD_EPOCH: u64 = 1_420_070_400_000;
 // `(u64::MAX >> 22) + DISCORD_EPOCH` = 5818116911103 = "Wed May 15 2154 07:35:11 GMT+0000"
@@ -74,10 +76,10 @@ impl Timestamp {
         x.map(Self).ok_or(InvalidTimestamp)
     }
 
-    pub(crate) fn from_discord_id(id: u64) -> Self {
+    pub(crate) fn from_snowflake(id: Snowflake) -> Self {
         // This can't fail because of the bit shifting
         // `(u64::MAX >> 22) + DISCORD_EPOCH` = 5818116911103 = "Wed May 15 2154 07:35:11 GMT+0000"
-        Self::from_millis(((id >> 22) + DISCORD_EPOCH) as i64).expect("can't fail")
+        Self::from_millis(((id.get() >> 22) + DISCORD_EPOCH) as i64).expect("can't fail")
     }
 
     /// Create a new `Timestamp` with the current date and time in UTC.
@@ -156,13 +158,13 @@ impl Timestamp {
             .expect("as the OffsetDateTime is always parsed from rfc3339, this should never fail");
     }
 
-    pub(crate) fn try_as_discord_id(self) -> Result<u64, TimestampOutOfRange> {
+    pub(crate) fn try_as_snowflake(self) -> Result<Snowflake, TimestampOutOfRange> {
         let unix_millis = TryInto::<u64>::try_into(self.unix_timestamp_millis())
             .map_err(|_| TimestampOutOfRange)?;
         if !(DISCORD_EPOCH..=MAX_DISCORD_ID_MILLIS).contains(&unix_millis) {
             return Err(TimestampOutOfRange);
         }
-        Ok((unix_millis - DISCORD_EPOCH) << 22)
+        Ok(Snowflake::new((unix_millis - DISCORD_EPOCH) << 22))
     }
 }
 
@@ -280,23 +282,23 @@ mod tests {
     }
 
     #[test]
-    fn test_try_as_discord_id() {
+    fn test_try_as_snowflake() {
         // https://docs.discord.com/developers/reference#convert-snowflake-to-datetime
         let timestamp = Timestamp::from_millis(1462015105796).unwrap();
-        let as_discord_id = timestamp.try_as_discord_id().unwrap();
+        let as_discord_id = timestamp.try_as_snowflake().unwrap();
         assert_eq!(as_discord_id, 175928847298985984);
 
         let too_early = Timestamp::from_millis((DISCORD_EPOCH - 1) as i64).unwrap();
-        let result = too_early.try_as_discord_id();
+        let result = too_early.try_as_snowflake();
         assert!(matches!(result, Err(TimestampOutOfRange)));
 
         let too_late = Timestamp::from_millis((MAX_DISCORD_ID_MILLIS + 1) as i64).unwrap();
-        let result = too_late.try_as_discord_id();
+        let result = too_late.try_as_snowflake();
         assert!(matches!(result, Err(TimestampOutOfRange)));
 
         // The Discord epoch itself should be a valid conversion, and should produce an id of 0.
         let just_right = Timestamp::from_millis(DISCORD_EPOCH as i64).unwrap();
-        let zero = just_right.try_as_discord_id().unwrap();
+        let zero = just_right.try_as_snowflake().unwrap();
         assert_eq!(zero, 0);
     }
 }

--- a/src/model/typing.rs
+++ b/src/model/typing.rs
@@ -76,7 +76,7 @@ impl Typing {
                     _ => (),
                 }
 
-                http.broadcast_typing(channel_id).await?;
+                http.broadcast_typing(channel_id.0).await?;
 
                 // It is unclear for how long typing persists after this method is called.
                 // It is generally assumed to be 7 or 10 seconds, so we use 7 to be safe.

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -672,7 +672,7 @@ impl UserId {
             recipient_id: self,
         };
 
-        let channel = cache_http.http().create_private_channel(&body).await?;
+        let channel: PrivateChannel = cache_http.http().create_private_channel(&body).await?;
 
         #[cfg(feature = "temp_cache")]
         if let Some(cache) = cache_http.cache() {
@@ -758,7 +758,7 @@ impl UserId {
             }
         }
 
-        let user = cache_http.http().get_user(self).await?;
+        let user: User = cache_http.http().get_user(self).await?;
 
         #[cfg(feature = "temp_cache")]
         {

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -12,7 +12,7 @@ use super::prelude::*;
 #[cfg(feature = "model")]
 use crate::builder::{CreateMessage, EditProfile};
 #[cfg(feature = "model")]
-use crate::http::Http;
+use crate::http::{Http, Pagination};
 #[cfg(feature = "model")]
 use crate::model::CacheHttp;
 use crate::model::utils::deserialize_null_as_default;
@@ -212,6 +212,23 @@ impl OnlineStatus {
             OnlineStatus::Invisible => "invisible",
             OnlineStatus::Offline => "offline",
             OnlineStatus::Online => "online",
+        }
+    }
+}
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum UserPagination {
+    After(UserId),
+    Before(UserId),
+}
+
+#[cfg(feature = "model")]
+impl From<UserPagination> for Pagination {
+    fn from(pagination: UserPagination) -> Self {
+        match pagination {
+            UserPagination::After(id) => Pagination::After(id.0),
+            UserPagination::Before(id) => Pagination::Before(id.0),
         }
     }
 }
@@ -758,7 +775,7 @@ impl UserId {
             }
         }
 
-        let user: User = cache_http.http().get_user(self).await?;
+        let user: User = cache_http.http().get_user(self.0).await?;
 
         #[cfg(feature = "temp_cache")]
         {

--- a/src/model/webhook.rs
+++ b/src/model/webhook.rs
@@ -144,7 +144,7 @@ impl Webhook {
     /// May also return an [`Error::Json`] if there is an error in deserialising Discord's
     /// response.
     pub async fn from_id(http: &Http, webhook_id: WebhookId) -> Result<Self> {
-        http.get_webhook(webhook_id).await
+        http.get_webhook(webhook_id.0).await
     }
 
     /// Retrieves a webhook given its Id and unique token.
@@ -180,7 +180,7 @@ impl Webhook {
         webhook_id: WebhookId,
         token: &str,
     ) -> Result<Self> {
-        http.get_webhook_with_token(webhook_id, token).await
+        http.get_webhook_with_token(webhook_id.0, token).await
     }
 
     /// Retrieves a webhook given its url.
@@ -226,9 +226,9 @@ impl Webhook {
     pub async fn delete(&self, http: &Http, reason: Option<&str>) -> Result<()> {
         match &self.token {
             Some(token) => {
-                http.delete_webhook_with_token(self.id, token.expose_secret(), reason).await
+                http.delete_webhook_with_token(self.id.0, token.expose_secret(), reason).await
             },
-            None => http.delete_webhook(self.id, reason).await,
+            None => http.delete_webhook(self.id.0, reason).await,
         }
     }
 
@@ -353,7 +353,7 @@ impl Webhook {
         message_id: MessageId,
     ) -> Result<Message> {
         let token = self.token.as_ref().ok_or(ModelError::NoTokenSet)?.expose_secret();
-        http.get_webhook_message(self.id, thread_id, token, message_id).await
+        http.get_webhook_message(self.id.0, thread_id.map(|id| id.0), token, message_id.0).await
     }
 
     /// Edits a webhook message with the fields set via the given builder.
@@ -394,7 +394,7 @@ impl Webhook {
         message_id: MessageId,
     ) -> Result<()> {
         let token = self.token.as_ref().ok_or(ModelError::NoTokenSet)?.expose_secret();
-        http.delete_webhook_message(self.id, thread_id, token, message_id).await
+        http.delete_webhook_message(self.id.0, thread_id.map(|id| id.0), token, message_id.0).await
     }
 
     /// Retrieves the latest information about the webhook, editing the webhook in-place.
@@ -412,7 +412,7 @@ impl Webhook {
     /// Or may return an [`Error::Json`] if there is an error deserialising Discord's response.
     pub async fn refresh(&mut self, http: &Http) -> Result<()> {
         let token = self.token.as_ref().ok_or(ModelError::NoTokenSet)?.expose_secret();
-        http.get_webhook_with_token(self.id, token).await.map(|replacement| {
+        http.get_webhook_with_token(self.id.0, token).await.map(|replacement| {
             *self = replacement;
         })
     }
@@ -443,6 +443,6 @@ impl WebhookId {
     ///
     /// [Manage Webhooks]: super::permissions::Permissions::MANAGE_WEBHOOKS
     pub async fn to_webhook(self, http: &Http) -> Result<Webhook> {
-        http.get_webhook(self).await
+        http.get_webhook(self.0).await
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -394,7 +394,7 @@ const MAX_DOMAIN_LEN: usize = {
 /// assert_eq!(token, "ig5AO-wdVWpCBtUUMxmgsWryqgsW3DChbKYOINftJ4DCrUbnkedoYZD0VOH1QLr-S3sV");
 /// ```
 #[must_use]
-pub fn parse_webhook(url: &Url) -> Option<(WebhookId, &str)> {
+pub fn parse_webhook(url: &Url) -> Option<(Snowflake, &str)> {
     let (webhook_id, token) = url.path().strip_prefix("/api/webhooks/")?.split_once('/')?;
     if !["http", "https"].contains(&url.scheme())
         || !DOMAINS.contains(&url.domain()?)


### PR DESCRIPTION
Second PR in a series to prepare serenity for splitting into multiple crates. Follow-up to #3584 (keeping as a draft until that is merged).

This introduces a base Id type named `Snowflake` (formerly `InnerId`) which the `http` module can use for all its API calls instead of any specific Id type. This removes the circular dependency between `Http` and the various Id types, given that many of them have model methods defined on them.

Additionally:
 * Adds a base `Pagination` type which `UserPagination` and `GuildPagination` can be converted into (and moves the latter types into `model`).
 * Changes `MessagePagination` to contain `Snowflake` instead of `MessageId`
 * Renames `Timestamp::{from,try_as}_discord_id` to `Timestamp::{from,try_as}_snowflake`
