### PR TITLE
Add JSON error codes + docs fixes

### DIFF
--- a/src/builder/create_forum_post.rs
+++ b/src/builder/create_forum_post.rs
@@ -61,13 +61,11 @@ impl<'a> CreateForumPost<'a> {
 
     /// How many seconds must a user wait before sending another message.
     ///
-    /// Bots, or users with the [`MANAGE_MESSAGES`] and/or [`MANAGE_CHANNELS`] permissions are
-    /// exempt from this restriction.
+    /// Bots, or users with the [`BYPASS_SLOWMODE`] permission, are exempt from this restriction.
     ///
     /// **Note**: Must be between 0 and 21600 seconds (360 minutes or 6 hours).
     ///
-    /// [`MANAGE_MESSAGES`]: crate::model::permissions::Permissions::MANAGE_MESSAGES
-    /// [`MANAGE_CHANNELS`]: crate::model::permissions::Permissions::MANAGE_CHANNELS
+    /// [`BYPASS_SLOWMODE`]: crate::model::permissions::Permissions::BYPASS_SLOWMODE
     #[doc(alias = "slowmode")]
     pub fn rate_limit_per_user(mut self, seconds: NonMaxU16) -> Self {
         self.rate_limit_per_user = Some(seconds);

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -176,6 +176,8 @@ impl<'a> CreateMessage<'a> {
     }
 
     /// Set the message this reply or forward is referring to.
+    ///
+    /// **Note**: The bot must be able to read a message's content in order to forward it.
     pub fn reference_message(mut self, reference: impl Into<MessageReference>) -> Self {
         self.message_reference = Some(reference.into());
         self

--- a/src/builder/create_thread.rs
+++ b/src/builder/create_thread.rs
@@ -56,13 +56,11 @@ impl<'a> CreateThread<'a> {
 
     /// How many seconds must a user wait before sending another message.
     ///
-    /// Bots, or users with the [`MANAGE_MESSAGES`] and/or [`MANAGE_CHANNELS`] permissions are
-    /// exempt from this restriction.
+    /// Bots, or users with the [`BYPASS_SLOWMODE`] permission, are exempt from this restriction.
     ///
     /// **Note**: Must be between 0 and 21600 seconds (360 minutes or 6 hours).
     ///
-    /// [`MANAGE_MESSAGES`]: crate::model::permissions::Permissions::MANAGE_MESSAGES
-    /// [`MANAGE_CHANNELS`]: crate::model::permissions::Permissions::MANAGE_CHANNELS
+    /// [`BYPASS_SLOWMODE`]: crate::model::permissions::Permissions::BYPASS_SLOWMODE
     #[doc(alias = "slowmode")]
     pub fn rate_limit_per_user(mut self, seconds: NonMaxU16) -> Self {
         self.rate_limit_per_user = Some(seconds);

--- a/src/builder/edit_channel.rs
+++ b/src/builder/edit_channel.rs
@@ -192,13 +192,11 @@ impl<'a> EditChannel<'a> {
 
     /// How many seconds must a user wait before sending another message.
     ///
-    /// Bots, or users with the [`MANAGE_MESSAGES`] and/or [`MANAGE_CHANNELS`] permissions are
-    /// exempt from this restriction.
+    /// Bots, or users with the [`BYPASS_SLOWMODE`] permission, are exempt from this restriction.
     ///
     /// **Note**: Must be between 0 and 21600 seconds (360 minutes or 6 hours).
     ///
-    /// [`MANAGE_MESSAGES`]: Permissions::MANAGE_MESSAGES
-    /// [`MANAGE_CHANNELS`]: Permissions::MANAGE_CHANNELS
+    /// [`BYPASS_SLOWMODE`]: crate::model::permissions::Permissions::BYPASS_SLOWMODE
     #[doc(alias = "slowmode")]
     pub fn rate_limit_per_user(mut self, seconds: NonMaxU16) -> Self {
         self.rate_limit_per_user = Some(seconds);

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -123,6 +123,7 @@ enum_number! {
         RequestEntityTooLarge = 40005,
         FeatureTemporarilyDisabled = 40006,
         UserBannedFromGuild = 40007,
+        OnlyOneChannelParentIdPerRequest = 40009,
         ConnectionRevoked = 40012,
         OnlyConsumableSkusCanBeConsumed = 40018,
         CanOnlyDeleteSandboxEntitlements = 40019,
@@ -253,6 +254,8 @@ enum_number! {
         AccessToJoiningNewServersLimited = 340015,
         OnboardingRequirementsNotMet = 350000,
         BelowOnboardingRequirements = 350001,
+
+        AccessToFileUploadsLimitedForGuild = 400001,
 
         FailedToBanUsers = 500000,
         PollVotingBlocked = 520000,

--- a/src/model/event/full_event.rs
+++ b/src/model/event/full_event.rs
@@ -131,6 +131,8 @@ full_event! {
     GuildIntegrationsUpdate { guild_id: GuildId };
     /// Dispatched when a user joins a guild.
     ///
+    /// This event may also be sent for users who are already members of the guild.
+    ///
     /// Provides the guild's id and the user's member data.
     ///
     /// Note: This event will not trigger unless the "guild members" privileged intent is enabled

--- a/src/model/event/mod.rs
+++ b/src/model/event/mod.rs
@@ -142,7 +142,7 @@ pub struct GuildAuditLogEntryCreateEvent {
     pub entry: AuditLogEntry,
 }
 
-/// Requires [`GatewayIntents::GUILD_MODERATION`].
+/// Requires [`GatewayIntents::GUILD_MODERATION`] or [`Permissions::VIEW_AUDIT_LOG`].
 ///
 /// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-ban-add).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
@@ -153,7 +153,7 @@ pub struct GuildBanAddEvent {
     pub user: User,
 }
 
-/// Requires [`GatewayIntents::GUILD_MODERATION`].
+/// Requires [`GatewayIntents::GUILD_MODERATION`] or [`Permissions::VIEW_AUDIT_LOG`].
 ///
 /// [Discord docs](https://docs.discord.com/developers/events/gateway-events#guild-ban-remove).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1221,7 +1221,9 @@ impl GuildId {
     /// Although not required, you should specify all channels' positions, regardless of whether
     /// they were updated. Otherwise, positioning can sometimes get weird.
     ///
-    /// **Note**: Requires the [Manage Channels] permission.
+    /// **Note**: Requires the [Manage Channels] permission at the guild level (or on the
+    /// channel’s current parent category). It does not require access to the individual channel,
+    /// so a full reordering may include channels the current user cannot view.
     ///
     /// # Errors
     ///

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -1153,9 +1153,15 @@ impl GuildId {
 
     /// Gets a user's voice state in this guild.
     ///
+    /// **Note**: If the specified user is connected to a voice channel, the current user must
+    /// have the [Connect] permission for that channel.
+    ///
     /// # Errors
     ///
-    /// Returns [`Error::Http`] if the user is not in a voice channel in this guild.
+    /// Returns [`Error::Http`] if the current user lacks permission, or if the user is not in a
+    /// voice channel in this guild.
+    ///
+    /// [Connect]: Permissions::CONNECT
     pub async fn get_user_voice_state(self, http: &Http, user_id: UserId) -> Result<VoiceState> {
         http.get_user_voice_state(self, user_id).await
     }

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -449,7 +449,7 @@ impl GuildId {
     ///
     /// Returns [`Error::Http`] if the current user lacks permission or if invalid data is given.
     ///
-    /// [Manage Events]: Permissions::CREATE_EVENTS
+    /// [Create Events]: Permissions::CREATE_EVENTS
     pub async fn create_scheduled_event(
         self,
         http: &Http,


### PR DESCRIPTION
Implements a handful of small changes from recent discord-api-docs PRs:

- Adds two JSON error codes ([#7797](https://github.com/discord/discord-api-docs/pull/7797), [#8485](https://github.com/discord/discord-api-docs/pull/8485))
- Clarifies `GUILD_MEMBER_ADD` behavior ([#8337](https://github.com/discord/discord-api-docs/pull/8337))
- Documents new message forwarding requirement ([#8295](https://github.com/discord/discord-api-docs/pull/8295))
- Updates `GUILD_BAN_ADD/REMOVE` permissions requirements ([#7948](https://github.com/discord/discord-api-docs/pull/7948))
- Clarifies channel reorder permissions requirements ([#8485](https://github.com/discord/discord-api-docs/pull/8485))
- Documents permissions requirement for `get_user_voice_state` ([#8416](https://github.com/discord/discord-api-docs/pull/8416))
- Updates permission requirements for bypassing slowmode ([#8194](https://github.com/discord/discord-api-docs/pull/8194))