### PR TITLE
Relax static lifetimes for `AutocompleteValue` `From` implementations

### DIFF
--- a/src/builder/create_interaction_response.rs
+++ b/src/builder/create_interaction_response.rs
@@ -318,7 +318,7 @@ impl<'a> From<Cow<'a, str>> for AutocompleteValue<'a> {
     }
 }
 
-impl From<String> for AutocompleteValue<'static> {
+impl From<String> for AutocompleteValue<'_> {
     fn from(value: String) -> Self {
         Self::String(Cow::Owned(value))
     }
@@ -330,13 +330,13 @@ impl<'a> From<&'a str> for AutocompleteValue<'a> {
     }
 }
 
-impl From<u64> for AutocompleteValue<'static> {
+impl From<u64> for AutocompleteValue<'_> {
     fn from(value: u64) -> Self {
         Self::Integer(value)
     }
 }
 
-impl From<f64> for AutocompleteValue<'static> {
+impl From<f64> for AutocompleteValue<'_> {
     fn from(value: f64) -> Self {
         Self::Float(value)
     }


### PR DESCRIPTION
Relaxes the output lifetime for `AutocompleteValue` `From` implementations that do not have an input lifetime.

While this mostly worked, any `u64`/`f64`/`String::into` for `AutocompleteValue` then inferred a static lifetime, which may not be what the user wanted.

In particular, when using `AutocompleteChoice::new`, since that static lifetime then leads to infer the same for the `AutocompleteChoice` itself, it blocks using a borrowed `str` for the name, so f.e. this fails to compile without this PR:

```rs
fn example(name: &str) -> AutocompleteChoice<'_> {
    AutocompleteChoice::new(name, 0u64)
}
```

In most cases, this shouldn't really be an issue since the lifetimes are covariant anyway, but it does lead to odd inference problems like above still.