### PR TITLE
Update audit log `Action`s and `Change`s

### DIFF
--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -362,7 +362,7 @@ pub struct CommandPermissions {
 ///
 /// [Discord docs](https://docs.discord.com/developers/interactions/application-commands#application-command-permissions-object-application-command-permissions-structure).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct CommandPermission {
     /// The [`RoleId`] or [`UserId`], depends on `kind` value.

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -488,7 +488,7 @@ pub struct ThreadsData {
 /// See [Discord](https://docs.discord.com/developers/resources/channel#default-reaction-object)
 /// [docs]()
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
 pub enum ForumEmoji {
     /// The id of a guild's custom emoji.
@@ -541,7 +541,7 @@ impl<'de> serde::Deserialize<'de> for ForumEmoji {
 ///
 /// See [Discord docs](https://docs.discord.com/developers/resources/channel#forum-tag-object)
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct ForumTag {
     /// The id of the tag.

--- a/src/model/guild/audit_log/change.rs
+++ b/src/model/guild/audit_log/change.rs
@@ -32,7 +32,7 @@ macro_rules! generate_change {
         $key:literal => $name:ident ($type:ty),
     )* ) => {
         #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
-        #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+        #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
         #[non_exhaustive]
         #[serde(tag = "key")]
         #[serde(rename_all = "snake_case")]
@@ -61,9 +61,9 @@ macro_rules! generate_change {
                 #[serde(rename = "new_value")]
                 new: Option<FixedArray<AffectedRole>>,
             },
-            /// Role was removed to a member.
+            /// Role was removed from a member.
             #[serde(rename = "$remove")]
-            RolesRemove {
+            RolesRemoved {
                 #[serde(skip_serializing_if = "Option::is_none")]
                 #[serde(rename = "old_value")]
                 old: Option<FixedArray<AffectedRole>>,
@@ -72,9 +72,21 @@ macro_rules! generate_change {
                 new: Option<FixedArray<AffectedRole>>,
             },
 
+            /// Permissions were updated for a command.
+            #[serde(untagged)]
+            CommandPermissions {
+                #[serde(skip_serializing_if = "Option::is_none")]
+                #[serde(rename = "old_value")]
+                old_value: Option<CommandPermission>,
+                #[serde(skip_serializing_if = "Option::is_none")]
+                #[serde(rename = "new_value")]
+                new_value: Option<CommandPermission>,
+            },
+
             /// Unknown key was changed.
+            #[serde(untagged)]
             Other {
-                name: FixedString,
+                key: FixedString,
                 #[serde(skip_serializing_if = "Option::is_none")]
                 #[serde(rename = "old_value")]
                 old_value: Option<Value>,
@@ -82,21 +94,25 @@ macro_rules! generate_change {
                 #[serde(rename = "new_value")]
                 new_value: Option<Value>,
             },
-
-            /// Unknown key was changed and was invalid
-            #[serde(other)]
-            Unknown
         }
 
         impl Change {
             #[must_use]
-            pub fn key(&self) -> &str {
+            pub fn key(&self) -> FixedString {
                 match self {
-                    $( Self::$name { .. } => $key, )*
-                    Self::RolesAdded { .. } => "$add",
-                    Self::RolesRemove { .. } => "$remove",
-                    Self::Other { name, .. } => name,
-                    Self::Unknown => "unknown",
+                    $( Self::$name { .. } => FixedString::from_static_trunc($key), )*
+                    Self::RolesAdded { .. } => FixedString::from_static_trunc("$add"),
+                    Self::RolesRemoved { .. } => FixedString::from_static_trunc("$remove"),
+                    Self::CommandPermissions { old_value, new_value } => {
+                        if let Some(old_value) = old_value {
+                            FixedString::from_string_trunc(old_value.id.to_string())
+                        } else if let Some (new_value) = new_value {
+                            FixedString::from_string_trunc(new_value.id.to_string())
+                        } else {
+                            FixedString::from_static_trunc("unknown")
+                        }
+                    }
+                    Self::Other { key, .. } => key.clone(),
                 }
             }
         }
@@ -120,7 +136,7 @@ generate_change! {
     "auto_archive_duration" => AutoArchiveDuration(u16),
     /// Availability of a sticker was changed.
     "available" => Available(bool),
-    /// User avatar was changed.
+    /// User or webhook avatar was changed.
     "avatar_hash" => AvatarHash(ImageHash),
     /// Guild banner was changed.
     "banner_hash" => BannerHash(ImageHash),
@@ -132,12 +148,16 @@ generate_change! {
     "code" => Code(FixedString),
     /// Role color was changed.
     "color" => Color(u32),
+    /// Role colors were changed.
+    "colors" => Colors(RoleColours),
     /// Member timeout state was changed.
     "communication_disabled_until" => CommunicationDisabledUntil(Timestamp),
     /// User was server deafened/undeafened.
     "deaf" => Deaf(bool),
     /// Default auto archive duration for newly created threads was changed.
     "default_auto_archive_duration" => DefaultAutoArchiveDuration(u16),
+    /// Default channels for onboarding were changed.
+    "default_channel_ids" => DefaultChannelIds(FixedArray<ChannelId>),
     /// Default message notification level for a server was changed.
     "default_message_notifications" => DefaultMessageNotifications(DefaultMessageNotificationLevel),
     /// Permission on a text or voice channel was denied for a role.
@@ -146,6 +166,10 @@ generate_change! {
     "description" => Description(FixedString),
     /// Guild's discovery splash was changed.
     "discovery_splash_hash" => DiscoverySplashHash(ImageHash),
+    /// Id of the emoji for a soundboard sound was changed.
+    "emoji_id" => EmojiId(EmojiId),
+    /// Unicode character of the emoji for a soundboard sound was changed.
+    "emoji_name" => EmojiName(FixedString),
     "enabled" => Enabled(bool),
     /// Integration emoticons was enabled/disabled.
     "enable_emoticons" => EnableEmoticons(bool),
@@ -218,8 +242,18 @@ generate_change! {
     "rate_limit_per_user" => RateLimitPerUser(u16),
     /// Region of a guild was changed.
     "region" => Region(FixedString),
+    /// Whether an onboarding prompt is required was changed.
+    "required" => Required(bool),
     /// ID of the rules channel was changed.
     "rules_channel_id" => RulesChannelId(ChannelId),
+    /// End time of a scheduled event was changed.
+    "scheduled_end_time" => ScheduledEndTime(Timestamp),
+    /// Start time of a scheduled event was changed.
+    "scheduled_start_time" => ScheduledStartTime(Timestamp),
+    /// Whether only one option can be selected for an onboarding prompt was changed.
+    "single_select" => SingleSelect(bool),
+    /// ID of a soundboard sound was changed.
+    "sound_id" => SoundId(SoundId),
     /// Invite splash page artwork was changed.
     "splash_hash" => SplashHash(ImageHash),
     /// Status of guild scheduled event was changed.
@@ -240,6 +274,8 @@ generate_change! {
     "type" => Type(EntityType),
     /// Unicode emoji of a role icon was changed.
     "unicode_emoji" => UnicodeEmoji(FixedString),
+    /// ID of the user associated with an entity was changed.
+    "user_id" => UserId(UserId),
     /// Maximum number of users in a voice channel was changed.
     "user_limit" => UserLimit(NonMaxU16),
     /// Number of uses of an invite was changed.
@@ -248,6 +284,8 @@ generate_change! {
     "vanity_url_code" => VanityUrlCode(FixedString),
     /// Required verification level for new members was changed.
     "verification_level" => VerificationLevel(VerificationLevel),
+    /// Volume of a soundboard sound was changed.
+    "volume" => Volume(f64),
     /// Channel of the server widget was changed.
     "widget_channel_id" => WidgetChannelId(ChannelId),
     /// Whether a widget is enabled or not was changed.

--- a/src/model/guild/audit_log/change.rs
+++ b/src/model/guild/audit_log/change.rs
@@ -130,6 +130,8 @@ generate_change! {
     "allow" => Allow(Permissions),
     /// Id of the application associated with an entity was changed.
     "application_id" => ApplicationId(ApplicationId),
+    /// Ids of the set of tags applied to a thread in a forum channel was changed.
+    "applied_tags" => AppliedTags(FixedArray<ForumTagId>),
     /// Whether a thread is archived was changed.
     "archived" => Archived(bool),
     /// Entity asset was changed.
@@ -138,12 +140,16 @@ generate_change! {
     "auto_archive_duration" => AutoArchiveDuration(u16),
     /// Availability status was changed.
     "available" => Available(bool),
+    /// Set of tags that can be used in a forum channel was changed.
+    "available_tags" => AvailableTags(FixedArray<ForumTag>),
     /// User or webhook avatar was changed.
     "avatar_hash" => AvatarHash(ImageHash),
     /// Banner image was changed.
     "banner_hash" => BannerHash(ImageHash),
     /// Voice channel bitrate was changed.
     "bitrate" => Bitrate(u32),
+    /// Primary color of a server profile banner was changed.
+    "brand_color_primary" => BrandColorPrimary(FixedString),
     /// Id of the channel associated with an entity was changed.
     "channel_id" => ChannelId(ChannelId),
     /// Invite code was changed.
@@ -162,6 +168,10 @@ generate_change! {
     "default_channel_ids" => DefaultChannelIds(FixedArray<ChannelId>),
     /// Default message notification level for a server was changed.
     "default_message_notifications" => DefaultMessageNotifications(DefaultMessageNotificationLevel),
+    /// Emoji to show in the add reaction button on a thread in a forum channel was changed.
+    "default_reaction_emoji" => DefaultReactionEmoji(ForumEmoji),
+    /// Initial rate limit per user to set on newly created threads in a channel was changed.
+    "default_thread_rate_limit_per_user" => DefaultThreadRateLimitPerUser(u16),
     /// Deny field of a permission overwrite was changed.
     "deny" => Deny(Permissions),
     /// Description of an entity was changed.
@@ -194,6 +204,8 @@ generate_change! {
     "flags" => Flags(u64),
     /// Format type of a sticker was changed.
     "format_type" => FormatType(StickerFormatType),
+    /// Ids of games included in a server profile were changed.
+    "game_application_ids" => GameApplicationIds(FixedArray<ApplicationId>),
     /// Id of the guild associated with an entity was changed.
     "guild_id" => GuildId(GuildId),
     /// Whether a role is pinned in the user listing was changed.
@@ -204,6 +216,8 @@ generate_change! {
     "id" => Id(GenericId),
     /// Cover image of a scheduled event was changed.
     "image_hash" => ImageHash(ImageHash),
+    /// Whether a prompt is present in an onboarding flow was changed.
+    "in_onboarding" => InOnboarding(bool),
     /// Private thread's invitable state was changed.
     "invitable" => Invitable(bool),
     /// Id of the user who created an invite was changed.
@@ -212,6 +226,8 @@ generate_change! {
     "location" => Location(FixedString),
     /// Locked status of a thread was changed.
     "locked" => Locked(bool),
+    /// Whether users must apply to join a guild was changed.
+    "manual_approval_enabled" => ManualApprovalEnabled(bool),
     /// How long an invite code lasts was changed.
     "max_age" => MaxAge(u32),
     /// Maximum uses of an invite was changed.
@@ -224,6 +240,8 @@ generate_change! {
     "mute" => Mute(bool),
     /// Name of an entity was changed.
     "name" => Name(FixedString),
+    // Undocumented type: server guide new member to-do's
+    // "new_member_actions" => NewMemberActions(FixedArray<>),
     /// Nickname of a member was changed.
     "nick" => Nick(FixedString),
     /// Whether a channel is age-restricted was changed.
@@ -238,20 +256,26 @@ generate_change! {
     "position" => Position(u32),
     /// Preferred locale of a guild was changed.
     "preferred_locale" => PreferredLocale(FixedString),
+    /// Whether a guild has the boost progress bar enabled was changed.
+    "premium_progress_bar_enabled" => PremiumProgressBarEnabled(bool),
     /// Privacy level of a stage instance was changed.
     "privacy_level" => PrivacyLevel(u64),
     /// Number of days after which inactive and role-unassigned members are kicked was changed.
     "prune_delete_days" => PruneDeleteDays(u64),
     /// Id of a public updates channel was changed.
     "public_updates_channel_id" => PublicUpdatesChannelId(ChannelId),
-    /// Ratelimit per user in a text channel was changed.
+    /// Rate limit per user in a text channel was changed.
     "rate_limit_per_user" => RateLimitPerUser(u16),
     /// Region of a guild was changed.
     "region" => Region(FixedString),
     /// Whether an onboarding prompt is required was changed.
     "required" => Required(bool),
+    // Undocumented type: server guide resource channels
+    // "resource_channels" => ResourceChannels(FixedArray<>),
     /// Roles assigned to a user upon accepting an invite were changed.
     "role_ids" => RoleIds(FixedArray<RoleId>),
+    /// Voice region Id for a voice or stage channel was changed.
+    "rtc_region" => RtcRegion(FixedString),
     /// Id of a rules channel was changed.
     "rules_channel_id" => RulesChannelId(ChannelId),
     /// End time of a scheduled event was changed.
@@ -278,6 +302,8 @@ generate_change! {
     "title" => Title(FixedString),
     /// Topic of a text channel or stage instance was changed.
     "topic" => Topic(FixedString),
+    // Undocumented type: server profile traits
+    // "traits" => Traits(FixedArray<>),
     /// Trigger metadata of an auto moderation rule was changed.
     "trigger_metadata" => TriggerMetadata(TriggerMetadata),
     /// Trigger type of an auto moderation rule was changed.
@@ -294,10 +320,18 @@ generate_change! {
     "uses" => Uses(u64),
     /// Guild invite vanity url was changed.
     "vanity_url_code" => VanityUrlCode(FixedString),
+    /// Whether server rules are enabled was changed.
+    "verification_enabled" => VerificationEnabled(bool),
     /// Required verification level for new members was changed.
     "verification_level" => VerificationLevel(VerificationLevel),
+    /// Video quality mode for a voice channel was changed.
+    "video_quality_mode" => VideoQualityMode(VideoQualityMode),
+    // Undocumented type: server profile visibility
+    // "visibility" => Visibility(),
     /// Volume of a soundboard sound was changed.
     "volume" => Volume(f64),
+    // Undocumented type: server guide welcome message
+    // "welcome_message" => WelcomeMessage(),
     /// Channel of a server widget was changed.
     "widget_channel_id" => WidgetChannelId(ChannelId),
     /// Whether a server widget is enabled was changed.

--- a/src/model/guild/audit_log/change.rs
+++ b/src/model/guild/audit_log/change.rs
@@ -120,29 +120,31 @@ macro_rules! generate_change {
 }
 
 generate_change! {
+    /// Actions that execute when an auto moderation rule is triggered were changed.
     "actions" => Actions(FixedArray<Action>),
     /// AFK channel was changed.
     "afk_channel_id" => AfkChannelId(ChannelId),
     /// AFK timeout duration was changed.
     "afk_timeout" => AfkTimeout(AfkTimeout),
-    /// Permission on a text or voice channel was allowed for a role.
+    /// Allow field of a permission overwrite was changed.
     "allow" => Allow(Permissions),
-    /// Application ID of the added or removed webhook or bot.
+    /// Id of the application associated with an entity was changed.
     "application_id" => ApplicationId(ApplicationId),
-    /// Thread is now archived/unarchived.
+    /// Whether a thread is archived was changed.
     "archived" => Archived(bool),
+    /// Entity asset was changed.
     "asset" => Asset(FixedString),
     /// Auto archive duration of a thread was changed.
     "auto_archive_duration" => AutoArchiveDuration(u16),
-    /// Availability of a sticker was changed.
+    /// Availability status was changed.
     "available" => Available(bool),
     /// User or webhook avatar was changed.
     "avatar_hash" => AvatarHash(ImageHash),
-    /// Guild banner was changed.
+    /// Banner image was changed.
     "banner_hash" => BannerHash(ImageHash),
     /// Voice channel bitrate was changed.
     "bitrate" => Bitrate(u32),
-    /// Channel for invite code or guild scheduled event was changed.
+    /// Id of the channel associated with an entity was changed.
     "channel_id" => ChannelId(ChannelId),
     /// Invite code was changed.
     "code" => Code(FixedString),
@@ -152,7 +154,7 @@ generate_change! {
     "colors" => Colors(RoleColours),
     /// Member timeout state was changed.
     "communication_disabled_until" => CommunicationDisabledUntil(Timestamp),
-    /// User was server deafened/undeafened.
+    /// whether a user is deafened in voice channels was changed.
     "deaf" => Deaf(bool),
     /// Default auto archive duration for newly created threads was changed.
     "default_auto_archive_duration" => DefaultAutoArchiveDuration(u16),
@@ -160,9 +162,9 @@ generate_change! {
     "default_channel_ids" => DefaultChannelIds(FixedArray<ChannelId>),
     /// Default message notification level for a server was changed.
     "default_message_notifications" => DefaultMessageNotifications(DefaultMessageNotificationLevel),
-    /// Permission on a text or voice channel was denied for a role.
+    /// Deny field of a permission overwrite was changed.
     "deny" => Deny(Permissions),
-    /// Description for guild, sticker, or guild scheduled event was changed.
+    /// Description of an entity was changed.
     "description" => Description(FixedString),
     /// Guild's discovery splash was changed.
     "discovery_splash_hash" => DiscoverySplashHash(ImageHash),
@@ -170,43 +172,47 @@ generate_change! {
     "emoji_id" => EmojiId(EmojiId),
     /// Unicode character of the emoji for a soundboard sound was changed.
     "emoji_name" => EmojiName(FixedString),
+    /// Enabled status was changed.
     "enabled" => Enabled(bool),
-    /// Integration emoticons was enabled/disabled.
+    /// Whether emoticons should be synced for an integration was changed.
     "enable_emoticons" => EnableEmoticons(bool),
-    /// Entity type of guild scheduled event was changed.
+    /// Entity type of a scheduled event was changed.
     "entity_type" => EntityType(u64),
+    /// Event type of an auto moderation rule was changed.
     "event_type" => EventType(AutomodEventType),
+    /// Channels not affected by an auto moderation rule were changed.
     "exempt_channels" => ExemptChannels(FixedArray<ChannelId>),
+    /// Roles not affected by an auto moderation rule were changed.
     "exempt_roles" => ExemptRoles(FixedArray<RoleId>),
-    /// Behavior of the expiration of an integration was changed.
+    /// Behavior of expiring subscribers for an integration was changed.
     "expire_behavior" => ExpireBehavior(u64),
-    /// Grace period of the expiration of an integration was changed.
+    /// Grace period before expiring subscribers for an integration was changed.
     "expire_grace_period" => ExpireGracePeriod(u64),
     /// Explicit content filter level of a guild was changed.
     "explicit_content_filter" => ExplicitContentFilter(ExplicitContentFilter),
-    /// Unknown but sent by discord
+    /// Flags of an entity were changed.
     "flags" => Flags(u64),
     /// Format type of a sticker was changed.
     "format_type" => FormatType(StickerFormatType),
-    /// Guild a sticker is in was changed.
+    /// Id of the guild associated with an entity was changed.
     "guild_id" => GuildId(GuildId),
-    /// Role is now displayed/no longer displayed separate from online users.
+    /// Whether a role is pinned in the user listing was changed.
     "hoist" => Hoist(bool),
-    /// Guild icon was changed.
+    /// Guild or role icon was changed.
     "icon_hash" => IconHash(ImageHash),
-    /// Guild scheduled event cover image was changed.
+    /// Id of an entity was changed.
     "id" => Id(GenericId),
-    /// ID of the changed entity.
+    /// Cover image of a scheduled event was changed.
     "image_hash" => ImageHash(ImageHash),
     /// Private thread's invitable state was changed.
     "invitable" => Invitable(bool),
-    /// ID of the user who created the invite.
+    /// Id of the user who created an invite was changed.
     "inviter_id" => InviterId(UserId),
-    /// Location for a guild scheduled event was changed.
+    /// Location for a scheduled event was changed.
     "location" => Location(FixedString),
-    /// Thread was locked/unlocked.
+    /// Locked status of a thread was changed.
     "locked" => Locked(bool),
-    /// How long invite code lasts was changed.
+    /// How long an invite code lasts was changed.
     "max_age" => MaxAge(u32),
     /// Maximum uses of an invite was changed.
     "max_uses" => MaxUses(u8),
@@ -214,29 +220,29 @@ generate_change! {
     "mentionable" => Mentionable(bool),
     /// Multi-factor authentication requirement was changed.
     "mfa_level" => MfaLevel(MfaLevel),
-    /// User was server muted/unmuted.
+    /// Whether a user is server muted was changed.
     "mute" => Mute(bool),
     /// Name of an entity was changed.
     "name" => Name(FixedString),
     /// Nickname of a member was changed.
     "nick" => Nick(FixedString),
-    /// Channel NSFW restriction was changed.
+    /// Whether a channel is age-restricted was changed.
     "nsfw" => Nsfw(bool),
     /// Owner of a guild was changed.
     "owner_id" => OwnerId(UserId),
     /// Permissions on a channel were changed.
     "permission_overwrites" => PermissionOverwrites(FixedArray<PermissionOverwrite>),
-    /// Permissions for a role were changed.
+    /// Permissions for an entity were changed.
     "permissions" => Permissions(Permissions),
     /// Channel or role position was changed.
     "position" => Position(u32),
     /// Preferred locale of a guild was changed.
     "preferred_locale" => PreferredLocale(FixedString),
-    /// Privacy level of the stage instance was changed.
+    /// Privacy level of a stage instance was changed.
     "privacy_level" => PrivacyLevel(u64),
     /// Number of days after which inactive and role-unassigned members are kicked was changed.
     "prune_delete_days" => PruneDeleteDays(u64),
-    /// ID of the public updates channel was changed.
+    /// Id of a public updates channel was changed.
     "public_updates_channel_id" => PublicUpdatesChannelId(ChannelId),
     /// Ratelimit per user in a text channel was changed.
     "rate_limit_per_user" => RateLimitPerUser(u16),
@@ -244,7 +250,9 @@ generate_change! {
     "region" => Region(FixedString),
     /// Whether an onboarding prompt is required was changed.
     "required" => Required(bool),
-    /// ID of the rules channel was changed.
+    /// Roles assigned to a user upon accepting an invite were changed.
+    "role_ids" => RoleIds(FixedArray<RoleId>),
+    /// Id of a rules channel was changed.
     "rules_channel_id" => RulesChannelId(ChannelId),
     /// End time of a scheduled event was changed.
     "scheduled_end_time" => ScheduledEndTime(Timestamp),
@@ -252,33 +260,37 @@ generate_change! {
     "scheduled_start_time" => ScheduledStartTime(Timestamp),
     /// Whether only one option can be selected for an onboarding prompt was changed.
     "single_select" => SingleSelect(bool),
-    /// ID of a soundboard sound was changed.
+    /// Id of a soundboard sound was changed.
     "sound_id" => SoundId(SoundId),
-    /// Invite splash page artwork was changed.
+    /// Guild splash image was changed.
     "splash_hash" => SplashHash(ImageHash),
-    /// Status of guild scheduled event was changed.
+    /// Status of a scheduled event was changed.
     "status" => Status(u64),
     /// System channel settings were changed.
     "system_channel_flags" => SystemChannelFlags(SystemChannelFlags),
-    /// ID of the system channel was changed.
+    /// Id of a system channel was changed.
     "system_channel_id" => SystemChannelId(ChannelId),
-    /// Related emoji of a sticker was changed.
+    /// Autocomplete/suggestion tags (related emoji) of a sticker were changed.
     "tags" => Tags(FixedString),
-    /// Whether an invite is temporary or never expires was changed.
+    /// Whether an invite only grants temporary membership was changed.
     "temporary" => Temporary(bool),
+    /// Title of an entity was changed.
+    "title" => Title(FixedString),
     /// Topic of a text channel or stage instance was changed.
     "topic" => Topic(FixedString),
+    /// Trigger metadata of an auto moderation rule was changed.
     "trigger_metadata" => TriggerMetadata(TriggerMetadata),
+    /// Trigger type of an auto moderation rule was changed.
     "trigger_type" => TriggerType(TriggerType),
-    /// Type of a created entity.
+    /// Type of an entity was changed.
     "type" => Type(EntityType),
     /// Unicode emoji of a role icon was changed.
     "unicode_emoji" => UnicodeEmoji(FixedString),
-    /// ID of the user associated with an entity was changed.
+    /// Id of the user associated with an entity was changed.
     "user_id" => UserId(UserId),
-    /// Maximum number of users in a voice channel was changed.
+    /// User limit of a voice channel was changed.
     "user_limit" => UserLimit(NonMaxU16),
-    /// Number of uses of an invite was changed.
+    /// Number of times an invite has been used was changed.
     "uses" => Uses(u64),
     /// Guild invite vanity url was changed.
     "vanity_url_code" => VanityUrlCode(FixedString),
@@ -286,9 +298,9 @@ generate_change! {
     "verification_level" => VerificationLevel(VerificationLevel),
     /// Volume of a soundboard sound was changed.
     "volume" => Volume(f64),
-    /// Channel of the server widget was changed.
+    /// Channel of a server widget was changed.
     "widget_channel_id" => WidgetChannelId(ChannelId),
-    /// Whether a widget is enabled or not was changed.
+    /// Whether a server widget is enabled was changed.
     "widget_enabled" => WidgetEnabled(bool),
 }
 

--- a/src/model/guild/audit_log/mod.rs
+++ b/src/model/guild/audit_log/mod.rs
@@ -32,8 +32,13 @@ pub enum Action {
     Sticker(StickerAction),
     ScheduledEvent(ScheduledEventAction),
     Thread(ThreadAction),
+    CommandPermissions(CommandPermissionsAction),
+    SoundboardSound(SoundboardSoundAction),
     AutoMod(AutoModAction),
     CreatorMonetization(CreatorMonetizationAction),
+    OnboardingPrompt(OnboardingPromptAction),
+    Onboarding(OnboardingAction),
+    ServerGuide(ServerGuideAction),
     VoiceChannelStatus(VoiceChannelStatusAction),
     Unknown(u16),
 }
@@ -56,8 +61,13 @@ impl Action {
             Self::Sticker(x) => x as u16,
             Self::ScheduledEvent(x) => x as u16,
             Self::Thread(x) => x as u16,
+            Self::CommandPermissions(x) => x as u16,
+            Self::SoundboardSound(x) => x as u16,
             Self::AutoMod(x) => x as u16,
             Self::CreatorMonetization(x) => x as u16,
+            Self::OnboardingPrompt(x) => x as u16,
+            Self::Onboarding(x) => x as u16,
+            Self::ServerGuide(x) => x as u16,
             Self::VoiceChannelStatus(x) => x as u16,
             Self::Unknown(x) => x,
         }
@@ -113,6 +123,10 @@ impl Action {
             110 => Action::Thread(ThreadAction::Create),
             111 => Action::Thread(ThreadAction::Update),
             112 => Action::Thread(ThreadAction::Delete),
+            121 => Action::CommandPermissions(CommandPermissionsAction::Update),
+            130 => Action::SoundboardSound(SoundboardSoundAction::Create),
+            131 => Action::SoundboardSound(SoundboardSoundAction::Update),
+            132 => Action::SoundboardSound(SoundboardSoundAction::Delete),
             140 => Action::AutoMod(AutoModAction::RuleCreate),
             141 => Action::AutoMod(AutoModAction::RuleUpdate),
             142 => Action::AutoMod(AutoModAction::RuleDelete),
@@ -122,6 +136,13 @@ impl Action {
             146 => Action::AutoMod(AutoModAction::QuarantineUser),
             150 => Action::CreatorMonetization(CreatorMonetizationAction::RequestCreated),
             151 => Action::CreatorMonetization(CreatorMonetizationAction::TermsAccepted),
+            163 => Action::OnboardingPrompt(OnboardingPromptAction::Create),
+            164 => Action::OnboardingPrompt(OnboardingPromptAction::Update),
+            165 => Action::OnboardingPrompt(OnboardingPromptAction::Delete),
+            166 => Action::Onboarding(OnboardingAction::Create),
+            167 => Action::Onboarding(OnboardingAction::Update),
+            190 => Action::ServerGuide(ServerGuideAction::Create),
+            191 => Action::ServerGuide(ServerGuideAction::Update),
             192 => Action::VoiceChannelStatus(VoiceChannelStatusAction::StatusCreate),
             193 => Action::VoiceChannelStatus(VoiceChannelStatusAction::StatusDelete),
             _ => Action::Unknown(value),
@@ -282,6 +303,24 @@ pub enum ThreadAction {
 
 /// [Discord docs](https://docs.discord.com/developers/resources/audit-log#audit-log-entry-object-audit-log-events).
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
+pub enum CommandPermissionsAction {
+    Update = 121,
+}
+
+/// [Discord docs](https://docs.discord.com/developers/resources/audit-log#audit-log-entry-object-audit-log-events).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
+pub enum SoundboardSoundAction {
+    Create = 130,
+    Update = 131,
+    Delete = 132,
+}
+
+/// [Discord docs](https://docs.discord.com/developers/resources/audit-log#audit-log-entry-object-audit-log-events).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
 pub enum AutoModAction {
@@ -301,6 +340,34 @@ pub enum AutoModAction {
 pub enum CreatorMonetizationAction {
     RequestCreated = 150,
     TermsAccepted = 151,
+}
+
+/// [Discord docs](https://docs.discord.com/developers/resources/audit-log#audit-log-entry-object-audit-log-events).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
+pub enum OnboardingPromptAction {
+    Create = 163,
+    Update = 164,
+    Delete = 165,
+}
+
+/// [Discord docs](https://docs.discord.com/developers/resources/audit-log#audit-log-entry-object-audit-log-events).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
+pub enum OnboardingAction {
+    Create = 166,
+    Update = 167,
+}
+
+/// [Discord docs](https://docs.discord.com/developers/resources/audit-log#audit-log-entry-object-audit-log-events).
+#[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
+#[derive(Copy, Clone, Debug)]
+#[non_exhaustive]
+pub enum ServerGuideAction {
+    Create = 190,
+    Update = 191,
 }
 
 /// [Discord docs](https://docs.discord.com/developers/resources/audit-log#audit-log-entry-object-audit-log-events).
@@ -330,8 +397,8 @@ pub struct AuditLogs {
     pub integrations: FixedArray<PartialIntegration>,
     /// List of threads referenced in the audit log.
     ///
-    /// Threads referenced in THREAD_CREATE and THREAD_UPDATE events are included in the threads
-    /// map since archived threads might not be kept in memory by clients.
+    /// Threads referenced in `THREAD_CREATE` and `THREAD_UPDATE` events are included in the
+    /// threads map since archived threads might not be kept in memory by clients.
     pub threads: FixedArray<GuildThread>,
     /// List of users referenced in the audit log.
     pub users: ExtractMap<UserId, User>,
@@ -359,21 +426,21 @@ pub struct PartialIntegration {
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[non_exhaustive]
 pub struct AuditLogEntry {
-    /// Determines to what entity an [`Self::action`] was used on.
+    /// The Id of the affected entity (webhook, user, role, etc.).
     pub target_id: Option<GenericId>,
-    /// Determines what action was done on a [`Self::target_id`]
+    /// The type of action that occurred.
     #[serde(rename = "action_type")]
     pub action: Action,
-    /// What was the reasoning by doing an action on a target? If there was one.
+    /// The reason for the change (1-512 characters).
     pub reason: Option<FixedString>,
-    /// The user that did this action on a target.
+    /// The user or app that made the changes.
     pub user_id: Option<UserId>,
-    /// What changes were made.
+    /// The changes made to the `target_id`.
     #[serde(default)]
     pub changes: Vec<Change>,
-    /// The id of this entry.
+    /// The Id of this entry.
     pub id: AuditLogEntryId,
-    /// Some optional data associated with this entry.
+    /// Additional info for certain event types.
     pub options: Option<AuditLogEntryOptions>,
 }
 
@@ -386,33 +453,36 @@ pub struct AuditLogEntryOptions {
     pub auto_moderation_rule_name: Option<FixedString>,
     /// Trigger type of the Auto Moderation rule that was triggered.
     pub auto_moderation_rule_trigger_type: Option<FixedString>,
-    /// ID of the app whose permissions were targeted.
+    /// Id of the app whose permissions were targeted.
     pub application_id: Option<ApplicationId>,
     /// Number of days after which inactive members were kicked.
     #[serde(default, with = "optional_string")]
     pub delete_member_days: Option<NonMaxU32>,
-    /// Number of members removed by the prune
+    /// Number of members removed by the prune.
     #[serde(default, with = "optional_string")]
     pub members_removed: Option<NonMaxU64>,
-    /// Channel in which the messages were deleted
+    /// Channel in which the entities were targeted.
     #[serde(default)]
     pub channel_id: Option<GenericChannelId>,
-    /// Number of deleted messages.
+    /// Number of entities that were targeted.
     #[serde(default, with = "optional_string")]
     pub count: Option<NonMaxU64>,
-    /// Id of the overwritten entity
+    /// Id of the overwritten entity.
     #[serde(default)]
     pub id: Option<GenericId>,
     /// Type of overwritten entity ("member" or "role").
     #[serde(default, rename = "type")]
     pub kind: Option<FixedString>,
-    /// Message that was pinned or unpinned.
+    /// Id of the message that was targeted.
     #[serde(default)]
     pub message_id: Option<MessageId>,
-    /// Name of the role if type is "role"
+    /// Name of the role if type is "role".
     #[serde(default)]
     pub role_name: Option<FixedString>,
-    /// The status of a voice channel when set.
+    /// The type of integration which performed the action.
+    #[serde(default)]
+    pub integration_type: Option<FixedString>,
+    /// The new voice channel status.
     #[serde(default)]
     pub status: Option<FixedString>,
 }
@@ -478,6 +548,10 @@ mod tests {
         assert_action!(Action::Thread(ThreadAction::Create), 110);
         assert_action!(Action::Thread(ThreadAction::Update), 111);
         assert_action!(Action::Thread(ThreadAction::Delete), 112);
+        assert_action!(Action::CommandPermissions(CommandPermissionsAction::Update), 121);
+        assert_action!(Action::SoundboardSound(SoundboardSoundAction::Create), 130);
+        assert_action!(Action::SoundboardSound(SoundboardSoundAction::Update), 131);
+        assert_action!(Action::SoundboardSound(SoundboardSoundAction::Delete), 132);
         assert_action!(Action::AutoMod(AutoModAction::RuleCreate), 140);
         assert_action!(Action::AutoMod(AutoModAction::RuleUpdate), 141);
         assert_action!(Action::AutoMod(AutoModAction::RuleDelete), 142);
@@ -487,6 +561,13 @@ mod tests {
         assert_action!(Action::AutoMod(AutoModAction::QuarantineUser), 146);
         assert_action!(Action::CreatorMonetization(CreatorMonetizationAction::RequestCreated), 150);
         assert_action!(Action::CreatorMonetization(CreatorMonetizationAction::TermsAccepted), 151);
+        assert_action!(Action::OnboardingPrompt(OnboardingPromptAction::Create), 163);
+        assert_action!(Action::OnboardingPrompt(OnboardingPromptAction::Update), 164);
+        assert_action!(Action::OnboardingPrompt(OnboardingPromptAction::Delete), 165);
+        assert_action!(Action::Onboarding(OnboardingAction::Create), 166);
+        assert_action!(Action::Onboarding(OnboardingAction::Update), 167);
+        assert_action!(Action::ServerGuide(ServerGuideAction::Create), 190);
+        assert_action!(Action::ServerGuide(ServerGuideAction::Update), 191);
         assert_action!(Action::VoiceChannelStatus(VoiceChannelStatusAction::StatusCreate), 192);
         assert_action!(Action::VoiceChannelStatus(VoiceChannelStatusAction::StatusDelete), 193);
         assert_action!(Action::Unknown(234), 234);

--- a/src/model/guild/audit_log/mod.rs
+++ b/src/model/guild/audit_log/mod.rs
@@ -122,7 +122,7 @@ impl Action {
             146 => Action::AutoMod(AutoModAction::QuarantineUser),
             150 => Action::CreatorMonetization(CreatorMonetizationAction::RequestCreated),
             151 => Action::CreatorMonetization(CreatorMonetizationAction::TermsAccepted),
-            192 => Action::VoiceChannelStatus(VoiceChannelStatusAction::StatusUpdate),
+            192 => Action::VoiceChannelStatus(VoiceChannelStatusAction::StatusCreate),
             193 => Action::VoiceChannelStatus(VoiceChannelStatusAction::StatusDelete),
             _ => Action::Unknown(value),
         }
@@ -308,7 +308,7 @@ pub enum CreatorMonetizationAction {
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
 pub enum VoiceChannelStatusAction {
-    StatusUpdate = 192,
+    StatusCreate = 192,
     StatusDelete = 193,
 }
 
@@ -487,7 +487,7 @@ mod tests {
         assert_action!(Action::AutoMod(AutoModAction::QuarantineUser), 146);
         assert_action!(Action::CreatorMonetization(CreatorMonetizationAction::RequestCreated), 150);
         assert_action!(Action::CreatorMonetization(CreatorMonetizationAction::TermsAccepted), 151);
-        assert_action!(Action::VoiceChannelStatus(VoiceChannelStatusAction::StatusUpdate), 192);
+        assert_action!(Action::VoiceChannelStatus(VoiceChannelStatusAction::StatusCreate), 192);
         assert_action!(Action::VoiceChannelStatus(VoiceChannelStatusAction::StatusDelete), 193);
         assert_action!(Action::Unknown(234), 234);
     }


### PR DESCRIPTION
This PR:
- Fixes name of `VoiceChannelStatusAction::StatusCreate` (discord-api-docs [#8400](https://github.com/discord/discord-api-docs/pull/8400))
- Adds missing `CommandPermissions`, `SoundboardSound`, `OnboardingPrompt`, `Onboarding`, and `ServerGuide` actions
- Adds missing `integration_type` field to `AuditLogEntryOptions`
- Updates `AuditLogEntry` and `AuditLogEntryOptions` docs
- Fixes `generate_change` macro so that it deserializes missing `Change` variants as `Other` and includes their data, rather than dumping them into an `Unknown` unit variant and discarding their data
- Adds many missing `Change` variants and cleans up the docs for existing variants

Some `Change` variants for onboarding and scheduled events (recurring rules) could not be added due to missing models. PRs for those models (and their builders) to follow.