### PR TITLE
Add file type filtering support for command options and file uploads

### DIFF
--- a/src/builder/create_command.rs
+++ b/src/builder/create_command.rs
@@ -320,8 +320,10 @@ impl<'a> CreateCommandOption<'a> {
         self
     }
 
-    /// If the option is an [`Attachment`], file types to filter for; can be `image`, `video`,
-    /// `audio`, or any dot-prefixed extension such as `.pdf`; max 10.
+    /// If the option is an [`Attachment`], sets the file types to filter for.
+    ///
+    /// Can be `image`, `video`, `audio`, or any dot-prefixed extension such as `.pdf`. Maximum of
+    /// 10 types.
     ///
     /// **Note**: This only matches against the file extension. See [File Type Filtering] for
     /// details.

--- a/src/builder/create_command.rs
+++ b/src/builder/create_command.rs
@@ -40,6 +40,8 @@ pub struct CreateCommandOption<'a> {
     min_length: Option<u16>,
     #[serde(default)]
     max_length: Option<u16>,
+    #[serde(skip_serializing_if = "<[_]>::is_empty")]
+    file_types: Cow<'a, [Cow<'a, str>]>,
     #[serde(default)]
     autocomplete: bool,
 }
@@ -68,6 +70,7 @@ impl<'a> CreateCommandOption<'a> {
             channel_types: Cow::default(),
             choices: Cow::default(),
             options: Cow::default(),
+            file_types: Cow::default(),
         }
     }
 
@@ -317,6 +320,19 @@ impl<'a> CreateCommandOption<'a> {
         self
     }
 
+    /// If the option is an [`Attachment`], file types to filter for; can be `image`, `video`,
+    /// `audio`, or any dot-prefixed extension such as `.pdf`; max 10.
+    ///
+    /// **Note**: This only matches against the file extension. See [File Type Filtering] for
+    /// details.
+    ///
+    /// [`Attachment`]: crate::model::application::CommandOptionType::Attachment
+    /// [File Type Filtering]: https://docs.discord.com/developers/reference#file-type-filtering
+    pub fn file_types(mut self, file_types: impl Into<Cow<'a, [Cow<'a, str>]>>) -> Self {
+        self.file_types = file_types.into();
+        self
+    }
+
     pub fn into_owned(self) -> CreateCommandOption<'static> {
         let Self {
             kind,
@@ -332,6 +348,7 @@ impl<'a> CreateCommandOption<'a> {
             max_value,
             min_length,
             max_length,
+            file_types,
             autocomplete,
         } = self;
         CreateCommandOption {
@@ -364,6 +381,9 @@ impl<'a> CreateCommandOption<'a> {
             max_value,
             min_length,
             max_length,
+            file_types: Cow::Owned(
+                file_types.into_owned().into_iter().map(|f| f.into_owned().into()).collect(),
+            ),
             autocomplete,
         }
     }

--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -817,6 +817,8 @@ pub struct CreateFileUpload<'a> {
     min_values: u8,
     max_values: u8,
     required: bool,
+    #[serde(skip_serializing_if = "<[_]>::is_empty")]
+    file_types: Cow<'a, [Cow<'a, str>]>,
 }
 
 impl<'a> CreateFileUpload<'a> {
@@ -828,6 +830,7 @@ impl<'a> CreateFileUpload<'a> {
             min_values: 1,
             max_values: 1,
             required: true,
+            file_types: Cow::default(),
         }
     }
 
@@ -850,6 +853,18 @@ impl<'a> CreateFileUpload<'a> {
         self
     }
 
+    /// File types to filter for; can be `image`, `video`, `audio`, or any dot-prefixed extension
+    /// such as `.pdf`; max 10. Defaults to empty, which permits any file type.
+    ///
+    /// **Note**: This only matches against the file extension. See [File Type Filtering] for
+    /// details.
+    ///
+    /// [File Type Filtering]: https://docs.discord.com/developers/reference#file-type-filtering
+    pub fn file_types(mut self, file_types: impl Into<Cow<'a, [Cow<'a, str>]>>) -> Self {
+        self.file_types = file_types.into();
+        self
+    }
+
     pub fn into_owned(self) -> CreateFileUpload<'static> {
         let Self {
             kind,
@@ -857,6 +872,7 @@ impl<'a> CreateFileUpload<'a> {
             min_values,
             max_values,
             required,
+            file_types,
         } = self;
         CreateFileUpload {
             kind,
@@ -864,6 +880,9 @@ impl<'a> CreateFileUpload<'a> {
             min_values,
             max_values,
             required,
+            file_types: Cow::Owned(
+                file_types.into_owned().into_iter().map(|f| f.into_owned().into()).collect(),
+            ),
         }
     }
 }

--- a/src/builder/create_components.rs
+++ b/src/builder/create_components.rs
@@ -853,8 +853,10 @@ impl<'a> CreateFileUpload<'a> {
         self
     }
 
-    /// File types to filter for; can be `image`, `video`, `audio`, or any dot-prefixed extension
-    /// such as `.pdf`; max 10. Defaults to empty, which permits any file type.
+    /// Sets the file types to filter for.
+    ///
+    /// Can be `image`, `video`, `audio`, or any dot-prefixed extension such as `.pdf`. Maximum of
+    /// 10 types.
     ///
     /// **Note**: This only matches against the file extension. See [File Type Filtering] for
     /// details.

--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -298,6 +298,16 @@ pub struct CommandOption {
     /// Maximum permitted length for String options
     #[serde(default)]
     pub max_length: Option<u16>,
+    /// If the option is an [`Attachment`], file types to filter for; can be `image`, `video`,
+    /// `audio`, or any dot-prefixed extension such as `.pdf`; max 10.
+    ///
+    /// **Note**: This only matches against the file extension. See [File Type Filtering] for
+    /// details.
+    ///
+    /// [`Attachment`]: CommandOptionType::Attachment
+    /// [File Type Filtering]: https://docs.discord.com/developers/reference#file-type-filtering
+    #[serde(default)]
+    pub file_types: FixedArray<FixedString>,
     #[serde(default)]
     pub autocomplete: bool,
 }

--- a/src/model/application/command.rs
+++ b/src/model/application/command.rs
@@ -298,8 +298,10 @@ pub struct CommandOption {
     /// Maximum permitted length for String options
     #[serde(default)]
     pub max_length: Option<u16>,
-    /// If the option is an [`Attachment`], file types to filter for; can be `image`, `video`,
-    /// `audio`, or any dot-prefixed extension such as `.pdf`; max 10.
+    /// If the option is an [`Attachment`], the file types to filter for.
+    ///
+    /// Can be `image`, `video`, `audio`, or any dot-prefixed extension such as `.pdf`. Maximum
+    /// of 10 types.
     ///
     /// **Note**: This only matches against the file extension. See [File Type Filtering] for
     /// details.


### PR DESCRIPTION
https://docs.discord.com/developers/change-log#filter-file-types-in-file-uploads-and-attachment-options

Open Questions:
1. I went with an array of strings to best mirror the docs, but an Enum of `Image`, `Video`, `Audio`, `Extension(String)` could be argued for. 
2. I'm not a fan of the:
```
Cow::Owned(
                file_types.into_owned().into_iter().map(|f| f.into_owned().into()).collect(),
            ),
```
but kinda ties into point one with how we want the api to look.