### PR TITLE
Make `{Command,Component,Modal}Interaction::channel` non-optional

### DIFF
--- a/src/model/application/command_interaction.rs
+++ b/src/model/application/command_interaction.rs
@@ -34,7 +34,7 @@ pub struct CommandInteraction {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub guild_id: Option<GuildId>,
     /// Channel that the interaction was sent from.
-    pub channel: Option<GenericInteractionChannel>,
+    pub channel: GenericInteractionChannel,
     /// The channel Id this interaction was sent from.
     pub channel_id: GenericChannelId,
     /// The `member` data for the invoking user.

--- a/src/model/application/component_interaction.rs
+++ b/src/model/application/component_interaction.rs
@@ -31,7 +31,7 @@ pub struct ComponentInteraction {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub guild_id: Option<GuildId>,
     /// Channel that the interaction was sent from.
-    pub channel: Option<GenericInteractionChannel>,
+    pub channel: GenericInteractionChannel,
     /// The channel Id this interaction was sent from.
     pub channel_id: GenericChannelId,
     /// The `member` data for the invoking user.

--- a/src/model/application/modal_interaction.rs
+++ b/src/model/application/modal_interaction.rs
@@ -31,7 +31,7 @@ pub struct ModalInteraction {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub guild_id: Option<GuildId>,
     /// Channel that the interaction was sent from.
-    pub channel: Option<GenericInteractionChannel>,
+    pub channel: GenericInteractionChannel,
     /// The channel Id this interaction was sent from.
     pub channel_id: GenericChannelId,
     /// The `member` data for the invoking user.


### PR DESCRIPTION
`{Command,Component,Modal}Interaction::channel` should always be present. This also matches `channel_id`, which is already required.

The original PR that added the `channel` fields (#2393) didn't note this and just matched what the Discord API docs said exactly.