### PR TITLE
Box `{Component,Modal}Interaction::member`

### DIFF
--- a/src/model/application/component_interaction.rs
+++ b/src/model/application/component_interaction.rs
@@ -38,7 +38,7 @@ pub struct ComponentInteraction {
     ///
     /// **Note**: It is only present if the interaction is triggered in a guild.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub member: Option<Member>,
+    pub member: Option<Box<Member>>,
     /// The `user` object for the invoking user.
     #[serde(default)]
     pub user: User,

--- a/src/model/application/modal_interaction.rs
+++ b/src/model/application/modal_interaction.rs
@@ -38,7 +38,7 @@ pub struct ModalInteraction {
     ///
     /// **Note**: It is only present if the interaction is triggered in a guild.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub member: Option<Member>,
+    pub member: Option<Box<Member>>,
     /// The `user` object for the invoking user.
     #[serde(default)]
     pub user: User,

--- a/src/model/event/mod.rs
+++ b/src/model/event/mod.rs
@@ -1149,7 +1149,6 @@ impl<'de> Deserialize<'de> for GatewayEvent {
 /// Event received over a websocket connection
 ///
 /// [Discord docs](https://docs.discord.com/developers/events/gateway-events#receive-events).
-#[expect(clippy::large_enum_variant)]
 #[cfg_attr(feature = "typesize", derive(typesize::derive::TypeSize))]
 #[derive(Clone, Debug, Deserialize, Serialize, EnumCount, VariantNames, IntoStaticStr)]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]


### PR DESCRIPTION
To match what has been done to `CommandInteraction` in the past and actually make its size reduction useful for `Interaction` (again?).
Also reduces the size of `Event`.

64-bit app type sizes without this PR:
```
ComponentInteraction: 1120 bytes
ModalInteraction: 1096 bytes
Interaction: 1120 bytes
Event: 1120 bytes
```

With this PR:
```
ComponentInteraction: 768 bytes
ModalInteraction: 744 bytes
Interaction: 792 bytes
Event: 792 bytes
```