### PR TITLE
Update tokio-tungstenite to 0.23.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ chrono = { version = "0.4.31", default-features = false, features = ["clock", "s
 flate2 = { version = "1.0.28", optional = true }
 reqwest = { version = ">=0.11.22", default-features = false, features = ["multipart", "stream"], optional = true }
 static_assertions = { version = "1.1.0", optional = true }
-tokio-tungstenite = { version = "0.21.0", optional = true }
+tokio-tungstenite = { version = "0.23.1", features = ["url"], optional = true }
 typemap_rev = { version = "0.3.0", optional = true }
 bytes = { version = "1.5.0", optional = true }
 percent-encoding = { version = "2.3.0", optional = true }


### PR DESCRIPTION
Updates the WebSocket TLS stack from rustls 0.22 / rustls-webpki 0.102 to rustls 0.23 / rustls-webpki 0.103. The explicit url feature preserves support for passing url::Url to connect_async_with_config after tokio-tungstenite made that feature non-default.\n\nThis is the smallest tokio-tungstenite release jump that moves to rustls 0.23.\n\nVerified with Serenity default-feature cargo check and by compiling a downstream Poise 0.6.2 application.