### PR TITLE
Ensure URL parameters are encoded safely, using reqwest's query feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ foldhash = { version = "0.2.0", optional = true }
 chrono = { version = "0.4.42", default-features = false, features = ["clock", "serde"], optional = true }
 flate2 = { version = "1.1.9", features = ["zlib-rs"], optional = true }
 zstd = { version = "0.13", default-features = false, optional = true }
-reqwest = { version = ">=0.13", default-features = false, features = ["multipart", "stream", "json"], optional = true }
+reqwest = { version = ">=0.13", default-features = false, features = ["multipart", "stream", "json", "query"], optional = true }
 tokio-tungstenite = { version = "0.28.0", features = ["url"], optional = true }
 percent-encoding = { version = "2.3.2", optional = true }
 mini-moka = { version = "0.10.3", optional = true }

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -164,3 +164,45 @@ impl<'a> Request<'a> {
         self.params
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+    use std::vec::Vec;
+
+    use super::*;
+    use crate::http::client::HttpBuilder;
+    use crate::model::id::GuildId;
+
+    // This test has to be async because Request::build is async, even though we don't use its async
+    // functionality here.
+    #[tokio::test]
+    async fn test_query_params_are_correctly_encoded() {
+        // Http::search_guild_members passes the query string unmodified into the Request struct
+        // expression. Let's see if it's handled correctly.
+        let guild_id = GuildId::default();
+        // This is actually a valid nickname on Discord. But since the & is also used to separate
+        // query arguments, it must be urlencoded before it can be sent.
+        let query = "foo&bar";
+        let limit = "50";
+
+        let sample_request = Request {
+            body: None,
+            multipart: None,
+            headers: None,
+            method: LightMethod::Get,
+            route: Route::GuildMembersSearch {
+                guild_id,
+            },
+            params: Some(&[("query", query), ("limit", limit)]),
+        };
+
+        let client = HttpBuilder::without_token().build();
+        let request_builder = sample_request.build(&client.client, None, None).await.unwrap();
+        let built = request_builder.build().unwrap();
+        let expected =
+            vec![(Cow::from("query"), Cow::from(query)), (Cow::from("limit"), Cow::from(limit))];
+        let actual = Vec::from_iter(built.url().query_pairs());
+        assert_eq!(actual, expected);
+    }
+}

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -1,5 +1,3 @@
-use std::fmt::Write;
-
 use reqwest::header::{
     AUTHORIZATION,
     CONTENT_LENGTH,
@@ -97,14 +95,11 @@ impl<'a> Request<'a> {
             path = path.replace("https://discord.com", proxy.trim_end_matches('/'));
         }
 
-        if let Some(params) = self.params {
-            path += "?";
-            for (param, value) in params {
-                write!(path, "&{param}={value}").expect("writing to a string should never fail");
-            }
-        }
-
         let mut builder = client.request(self.method.reqwest_method(), path);
+
+        if let Some(params) = self.params {
+            builder = builder.query(params);
+        }
 
         let mut headers = self.headers.unwrap_or_default();
         headers.insert(USER_AGENT, HeaderValue::from_static(SERENITY_USER_AGENT));


### PR DESCRIPTION
This does introduce an indirect dependency on serde_urlencode.

Fixes #3604.